### PR TITLE
Only print docker errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 
 test:
   override:
-    - docker run -v $(pwd):/app hackedu/markcop:latest
+    - docker run -v $(pwd):/app hackedu/markcop:latest -l error


### PR DESCRIPTION
This will remove the warning commments:

` WARNING: Your kernel does not support memory swappiness...`