### PR TITLE
[not ready to be merged] add maze workshop html page

### DIFF
--- a/workshops/README.md
+++ b/workshops/README.md
@@ -18,12 +18,13 @@ These are the workshops created and maintained by the hackEDU staff. They are
 listed in the order we suggest running them in, though we encourage you to
 experiment and improve them (we're always hungry for pull requests).
 
-| Workshop                                   | What You Build                             |
-| ------------------------------------------ | ------------------------------------------ |
-| [Portfolio](portfolio/README.md)           | A simple portfolio website                 |
-| [Remote Control](remote_control/README.md) | A website that makes phone calls and texts |
-| [Soccer](soccer/README.md)                 | A simple soccer game                       |
-| [Dodge](dodge/README.md)                   | A bullet dodging game                      |
+| Workshop                                                                                                           | What You Build                             |
+|:-------------------------------------------------------------------------------------------------------------------|:-------------------------------------------|
+| [Portfolio](portfolio/README.md)                                                                                   | A simple portfolio website                 |
+| [Remote Control](remote_control/README.md)                                                                         | A website that makes phone calls and texts |
+| [Soccer](soccer/README.md)                                                                                         | A simple soccer game                       |
+| [Dodge](dodge/README.md)                                                                                           | A bullet dodging game                      |
+| [Maze](http://cdn.rawgit.com/jonleung/hackedu/fa2a1cdd6c2d552278b5e49a8f646bd01243cd5f/workshops/maze/readme.html) | A "Scary Maze Game" clone                  |
 
 ## Community Workshops
 
@@ -33,6 +34,6 @@ community workshops that have been created so far are listed below in
 alphabetical order.
 
 | Workshop                           | What You Build                                                 | Author                                 |
-| ---------------------------------- | -------------------------------------------------------------- | -------------------------------------- |
+|:-----------------------------------|:---------------------------------------------------------------|:---------------------------------------|
 | [Ajar.io](contrib/ajar/README.md)  | A clone of Agar.io                                             | [@Bogidon](https://github.com/Bogidon) |
 | [Cloud9](contrib/cloud9/README.md) | A fully configured Cloud9 account ready to use for development | [@Bogidon](https://github.com/Bogidon) |


### PR DESCRIPTION
I am opening this pull request for now to start a discussion about linking to an HTML file which renders the `README.md` of the maze workshop instead of the `README.md` itself.

Originally in `workshops/README.md`, the link to the maze workshop links to workshops/maze/README.md, a Markdown file. In this pull request, I am suggesting that we link it to a much prettier and easier to use webpage instead; something that looks like this: http://cdn.rawgit.com/jonleung/hackedu/fa2a1cdd6c2d552278b5e49a8f646bd01243cd5f/workshops/maze/readme.html

The navigation on the left hand side makes the content a lot more accessible. It's also _much prettier_

Note that this pull request is not ready to be merged for a variety of reasons but primarily because I want to get the an agreement to linking to a rendered HTML file instead.

Some notes:

- I want to render the file on a gh-pages branch, so the final linked URL should look like this: `https://hackedu.github.io/hackedu/workshops/maze/readme.html
- people seem to like the HTML page more:
  > ![image](https://cloud.githubusercontent.com/assets/654941/11024237/735e065c-8640-11e5-80de-15508cb175cc.png)

\cc @zachlatta @MaxWofford @hellyeah
Also adding @Bogidon @paked @JevinSidhu @vaibhavyadaram @cydrobolt @ssun098