### PR TITLE
Hack Club rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ it. It's very appreciated!
 
 Our existing style guides:
 
-- [Markdown](https://github.com/hackedu/meta/blob/master/markdown_style_guide.md)
+- [Markdown](https://github.com/hackclub/meta/blob/master/markdown_style_guide.md)
 
 ## Naming conventions
 
@@ -200,7 +200,7 @@ First make sure that you've read the
 Below is the recommended contribution flow for submitting
 [case studies](case_studies/).
 
-1. Go to [Cloud9](https://c9.io/) and open your "hackedu" workspace.
+1. Go to [Cloud9](https://c9.io/) and open your "hackclub" workspace.
 2. Make sure that the email address associated with git is correct.
 
         $ git config user.email
@@ -216,7 +216,7 @@ Below is the recommended contribution flow for submitting
 
 4. Update your Hack Club fork.
 
-        $ git pull https://github.com/hackedu/hackedu.git
+        $ git pull https://github.com/hackclub/hackclub.git
 
 5. Create a new branch to add the case study to. Branch names should briefly
    describe the change being made. They should be lowercase and use dashes (`-`)
@@ -255,9 +255,9 @@ Below is the recommended contribution flow for submitting
 
         $ git push -u origin add-first-meeting-planning
 
-10. Go to your `hackedu` fork on GitHub (it's at
-    `https://github.com/{username}/hackedu`, mine is at
-    https://github.com/zachlatta/hackedu). You should see the following:
+10. Go to your `hackclub` fork on GitHub (it's at
+    `https://github.com/{username}/hackclub`, mine is at
+    https://github.com/zachlatta/hackclub). You should see the following:
 
     ![Recently pushed branches notification](https://i.imgur.com/NOeQyBe.png)
 
@@ -266,4 +266,4 @@ Below is the recommended contribution flow for submitting
     describe your changes in the description. Once you're ready, click "Create a
     pull request".
 12. And you're done! Not too bad, huh? The pull request I created is over at
-    https://github.com/hackedu/hackedu/pull/163.
+    https://github.com/hackclub/hackclub/pull/163.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Contributing to hackEDU
+# Contributing to Hack Club
 
-Contributions to hackEDU are very welcome, and strongly encouraged (even to this
-document)!
+Contributions to Hack Club are very welcome, and strongly encouraged (even to
+this document)!
 
 ## Doing it
 
 We use a modified version of
-[GitHub Flow](https://guides.github.com/introduction/flow/) at hackEDU. The only
-difference is instead of deploying from a reviewed pull request, we merge first
-and deploy straight from master.
+[GitHub Flow](https://guides.github.com/introduction/flow/) at Hack Club. The
+only difference is instead of deploying from a reviewed pull request, we merge
+first and deploy straight from master.
 
 Part of the GitHub Flow is submitting pull requests. See
 https://help.github.com/articles/using-pull-requests/ for a good overview of
@@ -129,7 +129,7 @@ change does.
 
 ## Using GitHub Issues
 
-We use GitHub's built in issue tracker for nearly everything at hackEDU. We
+We use GitHub's built in issue tracker for nearly everything at Hack Club. We
 recommend reading through https://guides.github.com/features/issues/ to get a
 good idea of how to use GitHub Issues.
 
@@ -214,7 +214,7 @@ Below is the recommended contribution flow for submitting
 
         $ git checkout master
 
-4. Update your hackEDU fork.
+4. Update your Hack Club fork.
 
         $ git pull https://github.com/hackedu/hackedu.git
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
-hackEDU (c)
+Hack Club (c)
 
-Code in this repository (hackEDU), including embedded code in other content, is
-licensed under the MIT license. All other content is licensed under a Creative
-Commons Attribution-ShareAlike 4.0 International License.
+Code in this repository (Hack Club), including embedded code in other content,
+is licensed under the MIT license. All other content is licensed under a
+Creative Commons Attribution-ShareAlike 4.0 International License.
 
 You have received a copy of the MIT and Creative Commons licenses along with
 this work in the MIT_LICENSE and CC_BY-SA_LICENSE files, respectively. An online
@@ -11,8 +11,8 @@ version of the Creative Commons license is available at
 
 --------------------------------------------------------------------------------
 
-In addition to the above license details, hackEDU includes third party code that
-has been made available under various licenses.
+In addition to the above license details, Hack Club includes third party code
+that has been made available under various licenses.
 
 twilio-node:
 

--- a/MIT_LICENSE
+++ b/MIT_LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 hackEDU
+Copyright (c) 2015 Hack Club
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <a name="top"></a>
 [![Slack Status](https://slack.hackclub.io/badge.svg)](https://slack.hackclub.io)
-[![Build Status](https://circleci.com/gh/hackedu/hackedu.svg?style=shield)](https://circleci.com/gh/hackedu/hackedu)
-[![Pull Request Stats](http://issuestats.com/github/hackedu/hackedu/badge/pr?style=flat)](http://issuestats.com/github/hackedu/hackedu)
-[![Issue Stats](http://issuestats.com/github/hackedu/hackedu/badge/issue?style=flat)](http://issuestats.com/github/hackedu/hackedu)
+[![Build Status](https://circleci.com/gh/hackclub/hackclub.svg?style=shield)](https://circleci.com/gh/hackclub/hackclub)
+[![Pull Request Stats](http://issuestats.com/github/hackclub/hackclub/badge/pr?style=flat)](http://issuestats.com/github/hackclub/hackclub)
+[![Issue Stats](http://issuestats.com/github/hackclub/hackclub/badge/issue?style=flat)](http://issuestats.com/github/hackclub/hackclub)
 
 ------------------------------------------------------------------------------
 
-<p align="center"><img src="https://raw.githubusercontent.com/hackedu/meta/5243af92814b6daacadd66e1342ad073e023544c/logos/hackedu_letter_opaque.png" alt="Hack Club"/></p>
+<p align="center"><img src="https://raw.githubusercontent.com/hackclub/meta/5243af92814b6daacadd66e1342ad073e023544c/logos/hackedu_letter_opaque.png" alt="Hack Club"/></p>
 <p align="center">
 <b><a href="workshops/README.md">workshops</a></b>
 |
@@ -32,7 +32,7 @@ Important links:
 
 Build Hack Club with us. Here are two ways to get started:
 
-- [Create an issue](https://github.com/hackedu/hackedu/issues)
+- [Create an issue](https://github.com/hackclub/hackclub/issues)
 - [Join our Slack](https://slack.hackclub.io)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ------------------------------------------------------------------------------
 
-<p align="center"><img src="https://raw.githubusercontent.com/hackedu/meta/5243af92814b6daacadd66e1342ad073e023544c/logos/hackedu_letter_opaque.png" alt="hackEDU"/></p>
+<p align="center"><img src="https://raw.githubusercontent.com/hackedu/meta/5243af92814b6daacadd66e1342ad073e023544c/logos/hackedu_letter_opaque.png" alt="Hack Club"/></p>
 <p align="center">
 <b><a href="workshops/README.md">workshops</a></b>
 |
@@ -17,11 +17,11 @@
 
 -------------------------------------------------------------------------------
 
-[hackEDU](https://hackclub.io) is the movement of student-led coding clubs. Want
-to start a Hack Club at your school? Apply over at https://hackclub.io/apply and
-[join our Slack](https://slack.hackclub.io) in the meantime. Regardless of
-whether you're part of hackEDU, we encourage you to check out and contribute to
-this repository.
+[Hack Club](https://hackclub.io) is the movement of student-led coding clubs.
+Want to start a Hack Club at your school? Apply over at
+https://hackclub.io/apply and [join our Slack](https://slack.hackclub.io) in the
+meantime. Regardless of whether you're part of Hack Club, we encourage you to
+check out and contribute to this repository.
 
 Important links:
 
@@ -30,7 +30,7 @@ Important links:
 
 ## Questions? Comments? Concerns?
 
-Build hackEDU with us. Here are two ways to get started:
+Build Hack Club with us. Here are two ways to get started:
 
 - [Create an issue](https://github.com/hackedu/hackedu/issues)
 - [Join our Slack](https://slack.hackclub.io)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a name="top"></a>
-[![Slack Status](https://slack.hackedu.us/badge.svg)](https://slack.hackedu.us)
+[![Slack Status](https://slack.hackclub.io/badge.svg)](https://slack.hackclub.io)
 [![Build Status](https://circleci.com/gh/hackedu/hackedu.svg?style=shield)](https://circleci.com/gh/hackedu/hackedu)
 [![Pull Request Stats](http://issuestats.com/github/hackedu/hackedu/badge/pr?style=flat)](http://issuestats.com/github/hackedu/hackedu)
 [![Issue Stats](http://issuestats.com/github/hackedu/hackedu/badge/issue?style=flat)](http://issuestats.com/github/hackedu/hackedu)
@@ -17,23 +17,23 @@
 
 -------------------------------------------------------------------------------
 
-[hackEDU](https://hackedu.us) is the movement of student-led coding clubs. Want
-to start a Hack Club at your school? Apply over at https://hackedu.us/apply and
-[join our Slack](https://slack.hackedu.us) in the meantime. Regardless of
+[hackEDU](https://hackclub.io) is the movement of student-led coding clubs. Want
+to start a Hack Club at your school? Apply over at https://hackclub.io/apply and
+[join our Slack](https://slack.hackclub.io) in the meantime. Regardless of
 whether you're part of hackEDU, we encourage you to check out and contribute to
 this repository.
 
 Important links:
 
 - [Workshops](workshops/README.md) :: Workshops for use in clubs
-- https://slack.hackedu.us :: Link to join our Slack community
+- https://slack.hackclub.io :: Link to join our Slack community
 
 ## Questions? Comments? Concerns?
 
 Build hackEDU with us. Here are two ways to get started:
 
 - [Create an issue](https://github.com/hackedu/hackedu/issues)
-- [Join our Slack](https://slack.hackedu.us)
+- [Join our Slack](https://slack.hackclub.io)
 
 ## Contributing
 

--- a/case_studies/cherry_hill_high_school_east/2015-09-21_c9_and_ajar.io_part_1/recap.md
+++ b/case_studies/cherry_hill_high_school_east/2015-09-21_c9_and_ajar.io_part_1/recap.md
@@ -3,7 +3,7 @@
 ![CHE CS at work](http://i.imgur.com/249LPMm.jpg?1)
 
 > *Dear reader*, these recaps were initially requested by
-> [hackedu](https://hackedu.us/) for other club organizers to read. However if
+> [hackedu](https://hackclub.io/) for other club organizers to read. However if
 > you're a club member you can use them to find out what happened at a meeting
 > you couldn't attend, if you just want to review some content, or for any
 > reason you want!

--- a/case_studies/glenaeon_rudolf_steiner_school/03_board_meeting/recap.md
+++ b/case_studies/glenaeon_rudolf_steiner_school/03_board_meeting/recap.md
@@ -13,7 +13,7 @@ One of the things I was asked to do was write a short proposal for our club.
 > We would like to start a student run code club within the school. It would meet
 > every Wednesday afternoon from 3:30-4:30 in the library. Ideally we would get
 > Chris to supervise the meetings. We would roughly follow the hackEDU
-> (http://hackedu.us) curriculum, a curriculum designed to quickly introduce
+> (http://hackclub.io) curriculum, a curriculum designed to quickly introduce
 > programming in a project oriented manner. I (Harrison) would manage the
 > workshops and ensure that each member is having their needs catered to. To make
 > sure each member has a workspace we would need access to the school computers.

--- a/case_studies/lowell_high_school/2015-09-05_first_meeting/planning.md
+++ b/case_studies/lowell_high_school/2015-09-05_first_meeting/planning.md
@@ -11,7 +11,7 @@
   - https://github.com/hackedu/hackedu/tree/jon-remote-control/playbook/workshops/remote_control
   - http://jonl.org/10-points-for-gryffindor/wand.html
 4. Open questions about anything in particular
-5. http://feedback.hackedu.us/#vallo
+5. http://feedback.hackclub.io/#vallo
 
 ## Expected Problems
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 
 test:
   override:
-    - docker run -v $(pwd):/app hackedu/markcop:latest
+    - docker run -v $(pwd):/app hackclub/markcop:latest

--- a/guidelines/collecting_feedback/README.md
+++ b/guidelines/collecting_feedback/README.md
@@ -1,7 +1,7 @@
 # Feedback Forms
 
 _This guide is a collection of info about feedback forms learned from
-[Hack Camp](https://github.com/hackedu/hack-camp)._
+[Hack Camp](https://github.com/hackclub/hack-camp)._
 
 ## Collecting Feedback
 

--- a/meta/labs/SETUP.md
+++ b/meta/labs/SETUP.md
@@ -9,7 +9,7 @@ The Labs program will follow this format:
   - Labs program workshops can be found in the
     (playbook)[https://github.com/hackedu/hackedu/tree/master/playbook/workshops]
 2. Case Studies
-  - To collect data from each meeting without core hackEDU team members being
+  - To collect data from each meeting without core Hack Club team members being
     there, each club meeting will have a case study
   - Each case study consists of 2 files:
     1. `planning.md`

--- a/meta/labs/SETUP.md
+++ b/meta/labs/SETUP.md
@@ -7,7 +7,7 @@ The Labs program will follow this format:
 1. Workshops
   - These are based on the workshops from Hack Camp
   - Labs program workshops can be found in the
-    (playbook)[https://github.com/hackedu/hackedu/tree/master/playbook/workshops]
+    (playbook)[https://github.com/hackclub/hackclub/tree/master/playbook/workshops]
 2. Case Studies
   - To collect data from each meeting without core Hack Club team members being
     there, each club meeting will have a case study
@@ -23,15 +23,15 @@ The Labs program will follow this format:
 Here's our checklist for getting everything going with Labs:
 
 - [x] Select everyone we're going to interview (_Deadline: 08.17.15_,
-  [#30](https://github.com/hackedu/hackedu/issues/30)).
+  [#30](https://github.com/hackclub/hackclub/issues/30)).
   - We're keeping track of people in the private sheet
     https://docs.google.com/spreadsheets/d/1Q6E36NK7N_mKp_LJwMW-P3KUZXPsHQTJWyoyKvrneuc.
 - [x] Schedule all interviews (_Deadline: 08.20.15_,
-  [#54](https://github.com/hackedu/hackedu/issues/31))
+  [#54](https://github.com/hackclub/hackclub/issues/31))
 - [x] Send out all acceptances and rejections (_Deadline: 08.25.15_,
-  [#48](https://github.com/hackedu/hackedu/issues/48))
+  [#48](https://github.com/hackclub/hackclub/issues/48))
 - [x] All acceptance contracts signed (_Deadline: 08.28.15_,
-  [#55](https://github.com/hackedu/hackedu/issues/55))
+  [#55](https://github.com/hackclub/hackclub/issues/55))
 
 ### Position Information
 

--- a/meta/labs/acceptance_email.md
+++ b/meta/labs/acceptance_email.md
@@ -13,7 +13,7 @@ your club, what isn't, and collaborating with the rest of the Labs Team to build
 (and document) the best club possible. The objective of the Labs Team is to
 build a playbook that makes it easy for anyone to start a great club (here's the
 playbook we used to run the last cohort of Hack Camp:
-https://github.com/hackedu/hack-camp/tree/master/cohort_4/playbook). We'll talk
+https://github.com/hackclub/hack-camp/tree/master/cohort_4/playbook). We'll talk
 more about what this collaboration process will look like once we've finished
 accepting everyone to Labs.
 

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -14,7 +14,7 @@ For more recommended guidelines on running workshops,
 
 ## Official Workshops
 
-These are the workshops created and maintained by the hackEDU staff. They are
+These are the workshops created and maintained by the Hack Club staff. They are
 listed in the order we suggest running them in, though we encourage you to
 experiment and improve them (we're always hungry for pull requests).
 
@@ -28,7 +28,7 @@ experiment and improve them (we're always hungry for pull requests).
 
 ## Community Workshops
 
-In addition to the workshops that the hackEDU staff make, anyone is encouraged
+In addition to the workshops that the Hack Club staff make, anyone is encouraged
 to create workshops and submit them to the [`contrib`](contrib/) directory. The
 community workshops that have been created so far are listed below in
 alphabetical order.

--- a/workshops/contrib/cloud9/README.md
+++ b/workshops/contrib/cloud9/README.md
@@ -20,7 +20,7 @@ __Imporatant__: if you're having trouble, checkout the
 
 First, make sure you have a github account. If you don't have one, follow the
 guide for making one located
-[here](https://github.com/hackedu/hackedu/tree/master/playbook/workshops/portfolio#creating-a-github-account).
+[here](https://github.com/hackclub/hackclub/tree/master/playbook/workshops/portfolio#creating-a-github-account).
 
 Now that you have a GitHub account, you can login to Cloud9 with GitHub. Go to
 http://c9.io and click on the "octocat" icon in the top corner, as demonstrated

--- a/workshops/dodge/add_enemy_sprite.md
+++ b/workshops/dodge/add_enemy_sprite.md
@@ -70,7 +70,7 @@ createSprite(150, 350, 8, 64);
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_
+[here](https://github.com/hackclub/hackclub/issues)_
 
 ## Table of Contents
 

--- a/workshops/dodge/add_player_sprite.md
+++ b/workshops/dodge/add_player_sprite.md
@@ -100,7 +100,7 @@ We learned how to:
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_
+[here](https://github.com/hackclub/hackclub/issues)_
 
 ## Table of Contents
 

--- a/workshops/dodge/arrow_key_movement.md
+++ b/workshops/dodge/arrow_key_movement.md
@@ -79,7 +79,7 @@ specifically, we learned how to make a sprite move when a key is pressed.
 
 *This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)*
+[here](https://github.com/hackclub/hackclub/issues)*
 
 ## Table of Contents
 

--- a/workshops/dodge/enemy_go_back_to_top.md
+++ b/workshops/dodge/enemy_go_back_to_top.md
@@ -70,7 +70,7 @@ Lets add our new code in:
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)._
+[here](https://github.com/hackclub/hackclub/issues)._
 
 ## Table of Contents
 

--- a/workshops/dodge/game_over.md
+++ b/workshops/dodge/game_over.md
@@ -84,7 +84,7 @@ This will remove the player and end the seemingly endless cycle!
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_
+[here](https://github.com/hackclub/hackclub/issues)_
 
 ## Table of Contents
 

--- a/workshops/dodge/linear_enemy_movement.md
+++ b/workshops/dodge/linear_enemy_movement.md
@@ -50,7 +50,7 @@ You should try play around with your own speed and find out what works the best!
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_
+[here](https://github.com/hackclub/hackclub/issues)_
 
 ## Table of Contents
 

--- a/workshops/dodge/linear_player_movement.md
+++ b/workshops/dodge/linear_player_movement.md
@@ -155,7 +155,7 @@ explain it!
 
 *This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)*
+[here](https://github.com/hackclub/hackclub/issues)*
 
 ## Table of Contents
 

--- a/workshops/dodge/player_image.md
+++ b/workshops/dodge/player_image.md
@@ -8,7 +8,7 @@
    anywhere it tells you to type `http://i.imgur.com/mOkHDqN.png`
    type this url instead:
 
-   https://cdn.rawgit.com/hackedu/hackedu/d44ce82f4bff5d9a083b5ee18d0aae6f4acf2bed/workshops/dodge/img/cube.png
+   https://cdn.rawgit.com/hackclub/hackclub/d44ce82f4bff5d9a083b5ee18d0aae6f4acf2bed/workshops/dodge/img/cube.png
 
 -------------------------------------------------------------------------------
 
@@ -93,7 +93,7 @@ practice for you to find your own!
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_.
+[here](https://github.com/hackclub/hackclub/issues)_.
 
 ### Follow Up Questions
 

--- a/workshops/dodge/random_enemy_position.md
+++ b/workshops/dodge/random_enemy_position.md
@@ -86,7 +86,7 @@ and press the `enter` key on your keyboard
 
 _This appendix is still being built! Is there something you have a question
 about? Submit an issue requesting its addition
-[here](https://github.com/hackedu/hackedu/issues)_
+[here](https://github.com/hackclub/hackclub/issues)_
 
 ## Table of Contents
 

--- a/workshops/lib/twilio-basic/signup.md
+++ b/workshops/lib/twilio-basic/signup.md
@@ -132,8 +132,8 @@ To get the actual promo code:
 
 - Ask your club leader for the Twilio promo code
 - If you are the club leader, get the promo code from
-  [`secrets.md`](https://github.com/hackedu/private/blob/master/secrets.md#twilio-promotion-code),
-  a file inside our [`private`](https://github.com/hackedu/private) GitHub
+  [`secrets.md`](https://github.com/hackclub/private/blob/master/secrets.md#twilio-promotion-code),
+  a file inside our [`private`](https://github.com/hackclub/private) GitHub
   repository.
 - If you don't have access to that repository, please email Jonathan at
   jonathanleung1337@gmail.com and ask for the Twilio promo code and he'll

--- a/workshops/lib/twilio-basic/signup.md
+++ b/workshops/lib/twilio-basic/signup.md
@@ -6,7 +6,7 @@ By the end of this tutorial, you will have a Twilio Account SID and Auth Token.
 receive text messages and phone calls minimal code. It's used heavily in one of
 our workshops and it's great for projects workshops use it.
 
-Twilio is giving every hackEDU member $100 worth of Twilio credit. This guide
+Twilio is giving every Hack Club member $100 worth of Twilio credit. This guide
 will walk you through the process if signing up for a Twilio Account.
 
 ## Creating an Account

--- a/workshops/lib/twilio-basic/src/js/loader.js
+++ b/workshops/lib/twilio-basic/src/js/loader.js
@@ -7,7 +7,7 @@ if (Twilio.ACCOUNT_SID.length !== 34 || Twilio.AUTH_TOKEN.length !== 32) {
   message = "You're almost there!" +
             " You need to make sure you've correctly added your Twilio " +
             " sid and token to your script tag first." +
-            " See https://github.com/hackedu/hackedu/tree/master/playbook/workshops/lib/twilio-basic/README.md + " +
+            " See https://github.com/hackclub/hackclub/tree/master/playbook/workshops/lib/twilio-basic/README.md + " +
             " for more details!";
   console.log(message);
   alert(message);

--- a/workshops/lib/twilio-basic/src/js/util/store_credentials.js
+++ b/workshops/lib/twilio-basic/src/js/util/store_credentials.js
@@ -55,7 +55,7 @@ if(sid === null || sid === "null") {
 
 while (sid === null || sid.length !== 34) {
   sid = prompt("You mistyped your Twilio ACCOUNT SID. Please retype it." +
-          " For help, check https://github.com/hackedu/hackedu/tree/master/playbook/workshops/lib/twilio-basic/README.md");
+          " For help, check https://github.com/hackclub/hackclub/tree/master/playbook/workshops/lib/twilio-basic/README.md");
 }
 localStorage.setItem(SID_KEY, sid);
 
@@ -65,7 +65,7 @@ if(token === undefined || token === null || token === "null") {
 
 while (token === null || token.length !== 32) {
   token = prompt("You mistyped your Twilio AUTH TOKEN. Please retype it." +
-          " For help, check https://github.com/hackedu/hackedu/tree/master/playbook/workshops/lib/twilio-basic/README.md");
+          " For help, check https://github.com/hackclub/hackclub/tree/master/playbook/workshops/lib/twilio-basic/README.md");
 }
 localStorage.setItem(TOKEN_KEY, token);
 

--- a/workshops/maze/README.md
+++ b/workshops/maze/README.md
@@ -19,7 +19,7 @@ scratch, we give you the code for how to make the maze game shown above and
 your mission will be to make your own version of it.
 
 This workshop also, assumes that you have done the
-[Dodge](https://github.com/hackedu/hackedu/blob/master/workshops/dodge/README.md)
+[Dodge](https://github.com/hackclub/hackclub/blob/master/workshops/dodge/README.md)
 workshop. Make sure you do that workshop first.
 
 ## 3. Setup
@@ -72,9 +72,9 @@ function draw() {
 For a refresher for how to do the following, see the corresponding sections from
 the Dodge workshop
 
-- [Creating a blank canvas](https://github.com/hackedu/hackedu/blob/master/workshops/dodge/blank_canvas.md)
-- [Adding a sprite](https://github.com/hackedu/hackedu/blob/master/workshops/dodge/add_player_sprite.md)
-- [Adding an image to your sprite](https://github.com/hackedu/hackedu/blob/master/workshops/dodge/player_image.md)
+- [Creating a blank canvas](https://github.com/hackclub/hackclub/blob/master/workshops/dodge/blank_canvas.md)
+- [Adding a sprite](https://github.com/hackclub/hackclub/blob/master/workshops/dodge/add_player_sprite.md)
+- [Adding an image to your sprite](https://github.com/hackclub/hackclub/blob/master/workshops/dodge/player_image.md)
 
 ### Game Over Condition
 
@@ -92,7 +92,7 @@ Note that `mouseX` represents the current **x** coordinate of the mouse and
 `mouseY` represents the current **y** coordinate of the mouse.
 
 For a refresher of the coordinate system, you can checkout
-<a href="https://github.com/hackedu/hackedu/blob/master/workshops/soccer/add_player_sprite.md#understanding-the-coordinate-system" target="_blank">
+<a href="https://github.com/hackclub/hackclub/blob/master/workshops/soccer/add_player_sprite.md#understanding-the-coordinate-system" target="_blank">
 this section</a> of the Soccer Workshop.
 
 With that, you can interpret the above line of code as:

--- a/workshops/maze/readme.html
+++ b/workshops/maze/readme.html
@@ -47,7 +47,7 @@
     <div class='left'>
       <h1>Friendly Maze Game</h1>
       <ul>
-        <li><a href='https://github.com/hackedu/hackedu/blob/master/workshops/maze/README.md'>View on GitHub</a></li>
+        <li><a href='https://github.com/hackclub/hackclub/blob/master/workshops/maze/README.md'>View on GitHub</a></li>
         <li><a href='https://github.com/USER/REPO/issues'>Issues</a></li>
       </ul>
     </div>

--- a/workshops/workshop_details.md
+++ b/workshops/workshop_details.md
@@ -109,9 +109,10 @@ directions here](twilio/signup.md) to do this. The workshop is set up so that th
 facilitator (that's you) obtains the credentials and gives it to everyone doing
 the workshop to save time.
 
-Following the above directions will give you $100 worth of credit. If any
-club members need more, they can follow the same instructions to get their own
-account. However, they will need you to give them the hackEDU Twilio promo code.
+Following the above directions will give you $100 worth of credit. If any club
+members need more, they can follow the same instructions to get their own
+account. However, they will need you to give them the Hack Club Twilio promo
+code.
 
 ##### Understanding The API
 


### PR DESCRIPTION
This PR changes (most) references of hackEDU to Hack Club. I've left out changes to case studies for the sake of preservation of history. I've also left out `surrogate.hackedu.us` because it'll require more work to move that over to `surrogate.hackclub.io`.