### PR TITLE
Create jsbinctl and refactor Portfolio to use it

### DIFF
--- a/workshops/lib/jsbinctl/README.md
+++ b/workshops/lib/jsbinctl/README.md
@@ -7,7 +7,7 @@ Make sure you have the [`gist`](https://github.com/defunkt/gist) gem installed
 before proceeding.
 
 Here's how it works. Your workshop directory structure should look like the
-following (where `how-to-make-a-plumbus` is your workshop):
+following (where `how_to_make_a_plumbus` is your workshop):
 
 ```
 workshops/
@@ -36,11 +36,12 @@ to these in your workshop's Markdown as follows:
 Let's build a plumbus. By the end of this workshop, we're going to end up with a
 plumbus that looks like [this][plumbus_prototype].
 
-[plumbus_prototype]: https://gist.jsbin.com/<gist_id>
+[plumbus_prototype]: https://jsbin.com/gist/206702bfb42906ab3dbf?output
 ```
 
-You can get the `<gist_id>` to use in the link by running `jsbinctl upload
-examples/<directory_name>`.
+You'll want to replace the included JS Bin link with your JS Bin URL. You can
+get one by running `jsbinctl upload examples/<directory_name>` (replacing
+`<directory_name>` with the name of the directory of the example to upload.)
 
 After you make changes to the local JS Bin example and want to update the link
 in the workshop, you can run `jsbinctl update examples/plumbus_prototype` to
@@ -48,3 +49,22 @@ update all reference links to the `plumbus_prototype` example.
 
 If you want to update all of the JS Bins example links, then run `jsbinctl
 update examples/*` and it'll take care of that for you.
+
+`jsbinctl` doesn't replace the JS Bin example's query string, allowing you to
+specify options like `?output` (if you only want the JS Bin to show the rendered
+output) and `?html,css` (if you only want the HTML and CSS of the JS Bin to be
+shown). It also will replace all reference links that _start_ with the JS Bin
+example directory (so you can have mutliple reference links for the same
+directory). The following examples are all valid:
+
+```md
+Let's talk some more about the plumbus. [Click here][plumbus_prototype_output]
+to see just our final output from this tutorial.
+[Click here](plumbus_prototype_code) to see just the code (with no output). And
+[click here](plumbus_prototype_js) to see just our JavaScript and rendered
+output.
+
+[plumbus_prototype_output]: https://jsbin.com/gist/206702bfb42906ab3dbf?output
+[plumbus_prototype_code]: https://jsbin.com/gist/206702bfb42906ab3dbf?html,css,js
+[plumbus_prototype_js]: https://jsbin.com/gist/206702bfb42906ab3dbf?js
+```

--- a/workshops/lib/jsbinctl/README.md
+++ b/workshops/lib/jsbinctl/README.md
@@ -1,0 +1,50 @@
+# `jsbinctl`
+
+This directory contains `jsbinctl`, our build system for the JS Bin examples in
+our workshops.
+
+Make sure you have the [`gist`](https://github.com/defunkt/gist) gem installed
+before proceeding.
+
+Here's how it works. Your workshop directory structure should look like the
+following (where `how-to-make-a-plumbus` is your workshop):
+
+```
+workshops/
+└── how_to_make_a_plumbus
+    ├── examples
+    │   ├── empty_site
+    │   │   ├── index.html
+    │   │   └── styles.css
+    │   ├── plumbus_image
+    │   │   ├── index.html
+    │   │   └── styles.css
+    │   └── plumbus_prototype
+    │       ├── index.html
+    │       ├── main.js
+    │       └── styles.css
+    ├── it_works.md
+    ├── prototyping_the_plumbus.md
+    ├── README.md
+    └── what_is_a_plumbus.md
+```
+
+Each directory in `examples` is an example to upload to JS Bin. You should link
+to these in your workshop's Markdown as follows:
+
+```md
+Let's build a plumbus. By the end of this workshop, we're going to end up with a
+plumbus that looks like [this][plumbus_prototype].
+
+[plumbus_prototype]: https://gist.jsbin.com/<gist_id>
+```
+
+You can get the `<gist_id>` to use in the link by running `jsbinctl upload
+examples/<directory_name>`.
+
+After you make changes to the local JS Bin example and want to update the link
+in the workshop, you can run `jsbinctl update examples/plumbus_prototype` to
+update all reference links to the `plumbus_prototype` example.
+
+If you want to update all of the JS Bins example links, then run `jsbinctl
+update examples/*` and it'll take care of that for you.

--- a/workshops/lib/jsbinctl/README.md
+++ b/workshops/lib/jsbinctl/README.md
@@ -6,6 +6,13 @@ our workshops.
 Make sure you have the [`gist`](https://github.com/defunkt/gist) gem installed
 before proceeding.
 
+Also, every time we say `jsbinctl`, replace it with a relative path to the
+`jsbinctl` script. If you're in the `workshops` directory, you'll want to
+replace it with `lib/jsbinctl/jsbinctl`. If you're in the `workshops/portfolio`
+directory, you'll want to replace it with `../lib/jsbinctl/jsbinctl`. If you're
+modifying a workshop, make sure you're in the workshop directory (ex.
+`workshops/twilio`) and use `../lib/jsbinctl/jsbinctl`.
+
 Here's how it works. Your workshop directory structure should look like the
 following (where `how_to_make_a_plumbus` is your workshop):
 

--- a/workshops/lib/jsbinctl/README.md
+++ b/workshops/lib/jsbinctl/README.md
@@ -47,8 +47,8 @@ After you make changes to the local JS Bin example and want to update the link
 in the workshop, you can run `jsbinctl update examples/plumbus_prototype` to
 update all reference links to the `plumbus_prototype` example.
 
-If you want to update all of the JS Bins example links, then run `jsbinctl
-update examples/*` and it'll take care of that for you.
+If you want to update all of the JS Bin example links, then run `jsbinctl update
+examples/*` and it'll take care of that for you.
 
 `jsbinctl` doesn't replace the JS Bin example's query string, allowing you to
 specify options like `?output` (if you only want the JS Bin to show the rendered

--- a/workshops/lib/jsbinctl/examples/plumbus_prototype/index.html
+++ b/workshops/lib/jsbinctl/examples/plumbus_prototype/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Plumbus Prototype</title>
+  </head>
+  <body>
+    <img src="https://i.imgur.com/NCqdPVt.png">
+  </body>
+</html>

--- a/workshops/lib/jsbinctl/examples/plumbus_prototype/main.js
+++ b/workshops/lib/jsbinctl/examples/plumbus_prototype/main.js
@@ -1,0 +1,1 @@
+console.log('And here we are, with our plumbus');

--- a/workshops/lib/jsbinctl/examples/plumbus_prototype/styles.css
+++ b/workshops/lib/jsbinctl/examples/plumbus_prototype/styles.css
@@ -1,0 +1,3 @@
+body {
+  background-color: #FAD8CC;
+}

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PLATFORM=$(uname)
+
 show_help() {
   cat <<EOF
 Usage: $0 [command]
@@ -69,9 +71,20 @@ update() {
     # 3) ?output,html
     local regex="\(\[$basename.*\]:\) \([^\?]*\)\(.*\)"
     local escaped_url=$(echo "$jsbin_url" | sed 's/\//\\\//g') # replace / with \/
+    local sed_exp="s/$regex/\1 $escaped_url\3/"
 
     # Do the replace!
-    find . -type f | xargs sed -i "s/$regex/\1 $escaped_url\3/"
+    #
+    # We provide an empty string as an argument to the -i option if we're on
+    # Darwin because BSD's sed automatically creates backup files. An empty
+    # string tells it not to create backups.
+    #
+    # The find commands are from https://stackoverflow.com/questions/4767396/linux-command-how-to-find-only-text-files
+    if [ $PLATFORM = "Darwin" ]; then
+      find . -type f -exec grep -Il "" {} \; | xargs sed -i '' "$sed_exp"
+    else
+      find . -type f -exec grep -Iq . {} \; -and -print | xargs sed -i "$sed_exp"
+    fi
   done
 }
 

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -56,9 +56,9 @@ update() {
     # match groups:
     #
     # 1) [example_name]:
-    # 2) https://gist.jsbin.com/old
-    # 3: ?output,html
-    local regex="\(\[$basename\]:\) \([^\?]*\)\(.*\)"
+    # 2) https://gist.jsbin.com/oldgistid
+    # 3) ?output,html
+    local regex="\(\[$basename.*\]:\) \([^\?]*\)\(.*\)"
     local escaped_url=$(echo "$jsbin_url" | sed 's/\//\\\//g') # replace / with \/
 
     # Do the replace!

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -33,7 +33,7 @@ upload() {
   fi
 
   local gist_id=${gist_output:24} # Chomp off the https://gist.github.com/ part
-  local jsbin_url="https://gist.jsbin.com/$gist_id"
+  local jsbin_url="https://jsbin.com/gist/$gist_id"
 
   echo $jsbin_url
 }

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -15,7 +15,16 @@ EOF
 }
 
 get_dir() {
-  echo $(readlink -f $1)
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
 }
 
 upload() {

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -20,8 +20,19 @@ get_dir() {
 
 upload() {
   local dir=$(get_dir $1)
-  local gist_url=$(gist -ap $dir/*)
-  local gist_id=${gist_url:24} # Chomp off the https://gist.github.com/ portion
+
+  # We have to split this up into multiple lines because the `local` command
+  # always returns 0 if used properly. We later want to use $? to see the exit
+  # status of the gist command.
+  local gist_output
+  gist_output=$(gist -ap $dir/*)
+  # If gist outputted an error, print its output and exit
+  if [ $? -ne 0 ]; then
+    echo $gist_output
+    exit $?
+  fi
+
+  local gist_id=${gist_output:24} # Chomp off the https://gist.github.com/ part
   local jsbin_url="https://gist.jsbin.com/$gist_id"
 
   echo $jsbin_url

--- a/workshops/lib/jsbinctl/jsbinctl
+++ b/workshops/lib/jsbinctl/jsbinctl
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+show_help() {
+  cat <<EOF
+Usage: $0 [command]
+
+Available commands:
+
+	upload	upload a JS Bin directory to a gist
+	update	upload to a gist and update all references in .md files
+
+EOF
+
+  exit 1
+}
+
+get_dir() {
+  echo $(readlink -f $1)
+}
+
+upload() {
+  local dir=$(get_dir $1)
+  local gist_url=$(gist -ap $dir/*)
+  local gist_id=${gist_url:24} # Chomp off the https://gist.github.com/ portion
+  local jsbin_url="https://gist.jsbin.com/$gist_id"
+
+  echo $jsbin_url
+}
+
+update() {
+  for dir in "$@"; do
+    local dir=$(get_dir $1)
+    local basename=$(basename $dir)
+    local jsbin_url=$(upload $dir)
+
+    echo "I'm about to update all $basename references to the new JS Bin URL"\
+         "($jsbin_url) in $(basename $PWD). Let me continue?"
+    select yn in "Yes" "No"; do
+      case $yn in
+        Yes ) break;;
+        No ) exit;;
+      esac
+    done
+
+    # match groups:
+    #
+    # 1) [example_name]:
+    # 2) https://gist.jsbin.com/old
+    # 3: ?output,html
+    local regex="\(\[$basename\]:\) \([^\?]*\)\(.*\)"
+    local escaped_url=$(echo "$jsbin_url" | sed 's/\//\\\//g') # replace / with \/
+
+    # Do the replace!
+    find . -type f | xargs sed -i "s/$regex/\1 $escaped_url\3/"
+  done
+}
+
+handle_command_line() {
+  local cmd=$1;
+  local args="${*:2}"
+
+  case $cmd in
+    "upload")
+      upload $args
+      ;;
+    "update")
+      update $args
+      ;;
+    *)
+      show_help
+      ;;
+  esac
+}
+
+if [ $# -eq 0 ]; then
+  show_help
+fi
+
+handle_command_line "$@"

--- a/workshops/portfolio/README.md
+++ b/workshops/portfolio/README.md
@@ -15,7 +15,7 @@ Your final design looks like this:
 
 Here is a link to a [live demo][final_output] live demo.
 
-And here is the [final code][final_output] for the live demo.
+And here is the [final code][final_output_code] for the live demo.
 
 To do this, you will be learning the basics of two languages: HTML and CSS.
 
@@ -23,7 +23,8 @@ Every website that you have ever seen are written in these two languages.
 
 We will be building this website on an online code editor called JS Bin.
 
-[final_output]: https://gist.jsbin.com/3b13a4fd3451a3ff1553?output
+[final_output]: https://jsbin.com/gist/81d45193dab5236afbba?output
+[final_output_code]: https://jsbin.com/gist/81d45193dab5236afbba?html,css,output
 
 ## Creating a GitHub account
 

--- a/workshops/portfolio/README.md
+++ b/workshops/portfolio/README.md
@@ -13,18 +13,17 @@ Your final design looks like this:
 
 > ![](img/final_1.png)
 
-Here is a link to a
-<a href="http://output.jsbin.com/fugoki/2" target="_blank">live demo</a>
+Here is a link to a [live demo][final_output] live demo.
 
-And here is the
-<a href="http://jsbin.com/fugoki/2/edit" target="_blank">final code</a>
-for the live demo.
+And here is the [final code][final_output] for the live demo.
 
 To do this, you will be learning the basics of two languages: HTML and CSS.
 
 Every website that you have ever seen are written in these two languages.
 
 We will be building this website on an online code editor called JS Bin.
+
+[final_output]: https://gist.jsbin.com/3b13a4fd3451a3ff1553?output
 
 ## Creating a GitHub account
 
@@ -37,9 +36,11 @@ GitHub also has a login feature similar to how Facebook has "Facebook login".
 Let's make a GitHub account so we can login to JS Bin and many websites in the
 programming ecosystem!
 
-### 1) In a new window, open <a href="https://github.com" target="_blank">github.com</a>
+### 1) In a new window, open [github.com][github]
 
 > ![](img/c9_v2_setup_1.png)
+
+[github]: https://github.com
 
 ### 2) Create an account with a valid email
 
@@ -59,10 +60,12 @@ And now we're done creating a GitHub account!
 
 Now that we have a GitHub account:
 
-1. open to <a href="http://jsbin.com" target="_blank">jsbin.com</a>
+1. open to [jsbin.com][jsbin]
 2. click "Login or Register"
 
 > ![](img/login_or_register.gif)
+
+[jsbin]: https://jsbin.com
 
 ## 4) Login with GitHub
 
@@ -124,13 +127,15 @@ Let's understand why:
 ## HTML Tags
 
 The code that we are writing on the left is called "HTML". (Feel free to [Google
-what HTML stands for and learn more about it)](https://www.google.com/search?q=html)
+what HTML stands for and learn more about it][google_html])
 
 Any adding blank lines or more than one space between your words in HTML does
 will not change what your website looks like.
 
 However we can change the style of some things on the page by adding **HTML
 tags**.
+
+[google_html]: https://www.google.com/search?q=html
 
 ## The Heading HTML Tag
 

--- a/workshops/portfolio/examples/final_output/index.html
+++ b/workshops/portfolio/examples/final_output/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <img src="http://i.imgur.com/C6P1T0G.jpg">
+
+    <h1>Jonathan Leung</h1>
+
+    <p>I welcome you to the internet.</p>
+  </body>
+</html>

--- a/workshops/portfolio/examples/final_output/styles.css
+++ b/workshops/portfolio/examples/final_output/styles.css
@@ -1,0 +1,9 @@
+body {
+  text-align: center;
+  font-family: arial;
+}
+
+img {
+  width: 200px;
+  border-radius: 50%;
+}


### PR DESCRIPTION
This PR creates `jsbinctl`, a super neat-o utility for managing our JS Bin examples. Its README (included in this pull request) should give better, more complete details on how it works.

The one downside to this pull request: given the nature of how reference links work in Markdown (for those unfamiliar, see the _reference_ portion of https://daringfireball.net/projects/markdown/syntax#link), workshops that use this build system won't be able to have JS Bin links open in new tabs. Given how difficult it currently is to edit workshops without the build system, I think this is a fair tradeoff until we figure out a better solution.

Closes #521.

/cc @MaxWofford @paked 