### PR TITLE
Fix irc channel name

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -34,7 +34,7 @@ Club groups and in person meetings and events including:
 - The [GitHub projects](https://github.com/hackclub/)
 - The [Facebook Group](https://www.facebook.com/groups/1501083703514499/)
 - The [Slack Channel](https://starthackclub.slack.com)
-- The #hackclub IRC channel on Freenode
+- The #hack-club IRC channel on Freenode
 - Club Meetings
 
 Other Hack Club groups (such as conferences, meetups, and other unofficial


### PR DESCRIPTION
when we migrated from hack edu we changed fro #hackedu to #hack-club.