### PR TITLE
Add standardized shortlinks for all workshops

### DIFF
--- a/workshops/ajar/README.md
+++ b/workshops/ajar/README.md
@@ -1,5 +1,7 @@
 # Ajar.io
 
+Short link to this workshop: https://workshops.hackclub.io/ajar
+
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 

--- a/workshops/cloud9/README.md
+++ b/workshops/cloud9/README.md
@@ -2,6 +2,8 @@
 
 ![Cloud9 logo](img/cloud9.png)
 
+Short link to this workshop: https://workshops.hackclub.io/cloud9
+
 ## What is Cloud9?
 
 *Cloud9 is a website that lets you program online*. Traditionally, all

--- a/workshops/cringe_101/README.md
+++ b/workshops/cringe_101/README.md
@@ -1,5 +1,7 @@
 # Cringe 101
 
+Short link to this workshop: https://workshops.hackclub.io/cringe_101
+
 ## Introduction
 
 <img src="https://d2mxuefqeaa7sj.cloudfront.net/s_1FACA745E7A5A03FBF7BCC2AF4856031BAC0AF7B12042E3DC78BDA872B3C6FBC_1448601896772_avoidance.jpg" alt="Cringe.gif" align="right" style="padding: 25px;" />

--- a/workshops/dodge/README.md
+++ b/workshops/dodge/README.md
@@ -1,5 +1,9 @@
 # Dodge
 
+Short link to this workshop: https://workshops.hackclub.io/dodge
+
+-------------------------------------------------------------------------------
+
 We are going to make a bullet dodging game:
 
 <a href="http://output.jsbin.com/dozoki/70"

--- a/workshops/git_and_github/README.md
+++ b/workshops/git_and_github/README.md
@@ -1,3 +1,7 @@
+Short link to this workshop: https://workshops.hackclub.io/git_and_github
+
+-------------------------------------------------------------------------------
+
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 

--- a/workshops/github_pages/README.md
+++ b/workshops/github_pages/README.md
@@ -1,5 +1,9 @@
 # GitHub Pages Workshop
 
+Short link to this workshop: https://workshops.hackclub.io/github_pages
+
+-------------------------------------------------------------------------------
+
 Welcome! In this workshop you will set up a GitHub Pages Website!
 
 To start you need to have completed the

--- a/workshops/maze/README.md
+++ b/workshops/maze/README.md
@@ -1,5 +1,7 @@
 # Friendly Maze Game
 
+Short link to this workshop: https://workshops.hackclub.io/maze
+
 ## 1. Demo
 
 Your mission is to build your own version of

--- a/workshops/portfolio/README.md
+++ b/workshops/portfolio/README.md
@@ -1,6 +1,6 @@
 # Building Your First Website
 
-Short link to this workshop: https://bit.ly/portfoliohack
+Short link to this workshop: https://workshops.hackclub.io/portfolio
 
 ## Goals
 

--- a/workshops/soccer/README.md
+++ b/workshops/soccer/README.md
@@ -1,5 +1,9 @@
 # Soccer
 
+Short link to this workshop: https://workshops.hackclub.io/soccer
+
+-------------------------------------------------------------------------------
+
 This tutorial is broken down into two parts:
 
 In [Part 1](#part-1-single-player-soccer), you learn to build a simple

--- a/workshops/twilio/README.md
+++ b/workshops/twilio/README.md
@@ -1,5 +1,9 @@
 # Introduction to Twilio
 
+Short link to this workshop: https://workshops.hackclub.io/twilio
+
+-------------------------------------------------------------------------------
+
 The objective of this workshop is to learn how to wield powerful
 [APIs](http://www.quora.com/What-is-an-API) with minimal code.
 


### PR DESCRIPTION
I set up https://workshops.hackclub.io to also support directly linking to workshops with https://workshops.hackclub.io/<workshop_directory_name>.

Closes #412.