### PR TITLE
Remove oven tag example

### DIFF
--- a/workshops/portfolio/README.md
+++ b/workshops/portfolio/README.md
@@ -272,14 +272,14 @@ Note that <img> does not have a closing tag
      (think of attributes like settings)
 ```
 
-For example, if an oven was a tag:
+For example, in an `<input>` tag:
 
 ```html
-<oven temperature="350">
+<input type="text">
 ```
 
-- `temperature` is the name of the attribute
-- `350` is the value of the `temperature` attribute
+- `type` is the name of the attribute
+- `"text"` is the value of the `type` attribute
 
 
 ```html


### PR DESCRIPTION
I think that the "oven" tag example is contrary to our teaching style. It is completely non applicable and invalid HTML: I've replaced it with an example which is *valid* HTML, and contains an element which a large majority of webpages use *somewhere*.