### PR TITLE
Improve beginning of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,55 @@
+# ![Hack Club logo](https://cdn.rawgit.com/hackclub/meta/82000f7457efdfc20b9feff4da718f6839e69c05/logos/hack_club_red_text.svg)
+
+Hack Club is the open-source movement of student-led high school coding clubs.
+
+Hack Clubs are after-school communities at high schools where people build
+things together. This repository contains the tools for starting and leading
+great clubs.
+
 [![Slack Status](https://slack.hackclub.io/badge.svg)](https://slack.hackclub.io)
 [![Build Status](https://circleci.com/gh/hackclub/hackclub.svg?style=shield)](https://circleci.com/gh/hackclub/hackclub)
 [![Pull Request Stats](http://issuestats.com/github/hackclub/hackclub/badge/pr?style=flat)](http://issuestats.com/github/hackclub/hackclub)
 [![Issue Stats](http://issuestats.com/github/hackclub/hackclub/badge/issue?style=flat)](http://issuestats.com/github/hackclub/hackclub)
 
-------------------------------------------------------------------------------
+Quick Hack Club links:
 
-<p align="center"><img src="https://cdn.rawgit.com/hackclub/meta/82000f7457efdfc20b9feff4da718f6839e69c05/logos/hack_club_red_text.svg" alt="Hack Club"/></p>
-
--------------------------------------------------------------------------------
-
-## Welcome to Hack Club
-
-<a href="https://hackclub.io">Hack Club</a> is a community of student-led coding
-clubs.
-
-| Action                                  | Link                          |
-| --------------------------------------- | ----------------------------- |
-| Chat with us _(we're here almost 24/7)_ | https://slack.hackclub.io     |
-| Start a club                            | https://hackclub.io/apply     |
-| See our workshops                       | https://workshops.hackclub.io |
-| Read our Code of Conduct                | [`CONDUCT.md`](CONDUCT.md)    |
-
-## About
-
-Hack Clubs are after-school communities at high schools where people build
-things together. This repo contains the tools for starting and leading great
-clubs.
+| Action                                    | Link                          |
+| ----------------------------------------- | ----------------------------- |
+| Join the Slack _(we're here almost 24/7)_ | https://slack.hackclub.io     |
+| See our workshops                         | https://workshops.hackclub.io |
+| Start a club                              | https://hackclub.io/apply     |
+| See our website                           | https://hackclub.io           |
+| Read our code of conduct                  | [`CONDUCT.md`](CONDUCT.md)    |
 
 ## Contributing
 
 Contributions are welcome!
 
 If you need any help, please contact us at team@hackclub.io or on our
-[slack](https://slack.hackclub.io).
+[Slack](https://slack.hackclub.io).
 
-1. Check out our
-   [public issues board](https://github.com/hackclub/hackclub/issues). If your
-   issue isn't on the board,
-   [open a new one](https://github.com/hackclub/hackclub/issues/new).
+1. Check out our [public issues board][0]. If your issue isn't on the board,
+   [open a new one][1].
 2. Pick an issue that nobody has claimed and start working on it. First time
    contributors should look for the
-   "[first-timers-only](https://github.com/hackclub/hackclub/labels/first-timers-only)"
+   "[first-timers-only][2]"
    label on issues.
-3. Fork the project
-   ([Need help forking a project?](https://help.github.com/articles/fork-a-repo/)).
-   You'll do all of your work on your forked copy.
+3. Fork the project ([Need help forking a project?][3]). You'll do all of your
+   work on your forked copy.
 4. Create a branch specific to the issue or feature you are working on. Push
-   your work on that branch
-   ([Need help with branching?](https://github.com/Kunena/Kunena-Forum/wiki/Create-a-new-branch-with-git-and-manage-branches)).
+   your work on that branch ([Need help with branching?][4]).
 5. Name the branch something like `fixes-xxx-issue` or `add-xx-feature` where
    `xxx` is a short description of the changes or feature you are adding.
-6. Your changes should follow Hack Club's
-   [styleguides](https://github.com/hackclub/meta/blob/master/styleguides/markdown.md).
+6. Your changes should follow our [styleguides][5].
 7. Once your code is ready, submit a pull request from your branch to Hack
    Club's `master` branch. We'll do a quick review and give you feedback.
+
+[0]: https://github.com/hackclub/hackclub/issues
+[1]: https://github.com/hackclub/hackclub/issues/new
+[2]: https://github.com/hackclub/hackclub/labels/first-timers-only
+[3]: https://help.github.com/articles/fork-a-repo/
+[4]: https://github.com/Kunena/Kunena-Forum/wiki/Create-a-new-branch-with-git-and-manage-branches
+[5]: https://github.com/hackclub/meta/blob/master/styleguides/markdown.md
 
 ## Additional Links
 
@@ -66,4 +62,7 @@ If you need any help, please contact us at team@hackclub.io or on our
 
 ## License
 
-For this project's license, please see [`LICENSE`](LICENSE).
+TL;DR: All content is released under the
+[Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)
+license. All code is released under the [MIT License](MIT_LICENSE). For the
+license's full text and attributions, please see [`LICENSE`](LICENSE).


### PR DESCRIPTION
This pull request takes your regular ol' `README`, which starts like this:

![tmp](https://cloud.githubusercontent.com/assets/992248/12080899/d0aba058-b21e-11e5-9926-765a6e601afc.png)

And makes it look all neat-o, like this:

![tmp](https://cloud.githubusercontent.com/assets/992248/12080900/e238ef56-b21e-11e5-9e1c-345ec11dc355.png)
