### PR TITLE
Link to Slack onboarding instead of Slackin

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -33,7 +33,7 @@ Club groups, in person meetings, and events including:
 
 - The [GitHub projects](https://github.com/hackclub/)
 - The [Facebook Group](https://www.facebook.com/groups/1501083703514499/)
-- The [Slack](https://starthackclub.slack.com)
+- The [Slack](SLACK.md)
 - The #hack-club IRC channel on Freenode
 - Club Meetings
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quick Hack Club links:
 
 | Action                                    | Link                          |
 | ----------------------------------------- | ----------------------------- |
-| Join the Slack _(we're here almost 24/7)_ | https://slack.hackclub.io     |
+| Join the Slack _(we're here almost 24/7)_ | [`SLACK.md`](SLACK.md)        |
 | See our workshops                         | https://workshops.hackclub.io |
 | Start a club                              | https://hackclub.io/apply     |
 | See our website                           | https://hackclub.io           |
@@ -26,7 +26,7 @@ Quick Hack Club links:
 Contributions are welcome!
 
 If you need any help, please contact us at team@hackclub.io or on our
-[Slack](https://slack.hackclub.io).
+[Slack](SLACK.md).
 
 1. Check out our [public issues board][0]. If your issue isn't on the board,
    [open a new one][1].

--- a/workshops/CONTRIBUTING.md
+++ b/workshops/CONTRIBUTING.md
@@ -7,13 +7,9 @@ Any contributions to our workshops are _very_ welcome, even from beginners!
 ## We Love Questions
 
 Before we get started, if you ever have any questions about anything or just
-want to talk through something, you can reach us almost 24/7 on our Slack.
-
-To ask a question on our Slack:
-
-1. Join our Slack: [https://slack.hackclub.io](https://slack.hackclub.io)
-2. Then join the `#curriculum` channel: [https://starthackclub.slack.com/messages/curriculum/](https://starthackclub.slack.com/messages/curriculum/)
-3. Ask your question!
+want to talk through something, you can reach us almost 24/7 on the
+`#curriculum` channel in our Slack ([click here](../SLACK.md) for instructions
+on joining).
 
 ## How to Contribute to the Workshops
 


### PR DESCRIPTION
This pull request changes links to our Slack from https://slack.hackclub.io to `SLACK.md` in the root of the repository.

The only reference to our Slack this doesn't change is in the case studies (for archival purposes) and https://github.com/hackclub/hackclub/blob/master/CONTRIBUTING.md#talk-about-it-on-slack because I'm waiting on #636 to be merged.