### PR TITLE
Create initial workshop progression plan

### DIFF
--- a/workshops/ARC.md
+++ b/workshops/ARC.md
@@ -1,0 +1,46 @@
+# Workshops Arc
+
+This document outlines our curriculum arc. In many ways, this is the syllabus
+for Hack Club.
+
+Hack Clubs are after-school high school clubs where people build things
+together. They can almost be thought of as never-ending hackathons, where club
+members come together twice a week (generally for ~1.5 hours) and work on
+projects together. Throughout the school year, Hack Clubs go (and sometimes
+host) hackathons, work on larger group projects, and---most importantly---build
+a thriving community of hackers at their high schools.
+
+While the goal with Hack Clubs is for most meetings to be free-form time where
+hackers are working on projects together, we're actively developing a series of
+open-source workshops to bring members from no experience to the point where
+they can hack on projects.
+
+Hackers use the following tools for workshops:
+
+- [Cloud9](https://c9.io/) - development environment
+- [GitHub](https://github.com/) - code host
+  - All Hack Club development goes into a
+    [GitHub Pages](https://pages.github.com/) repository called
+    `[username].github.io` (replacing `[username]` with their GitHub username)
+  - Each project done in Hack Club (so at least each workshop) goes into a
+    sub-directory called `project_name` in the main `[username].github.io`
+    project. The hackers should be regularly committing and pushing. For
+    example, if I were doing the Portfolio workshop, I'd put my work in
+    `[username].github.io/portfolio/`.
+
+Below is the initial plan for the Hack Club workshop progression. The `Week #`
+column is the week since the club's first meeting that the concept and workshop
+should be run. `Meeting #` is the meeting that it should be run in. It assumes
+that meetings happen twice a week and that every other meeting is free-form time
+for hacking.
+
+| Week # | Meeting # | Concept                       | Workshop (blank if not created yet) |
+| ------ | --------- | ----------------------------- | ----------------------------------- |
+|      1 |         1 | First code ever (HTML & CSS)  | [Portfolio][portfolio]              |
+|      2 |         3 | Hack Club onboarding          |                                     |
+|      2 |         3 | First JavaScript ever         | [Twilio][twilio]                    |
+|      3 |         5 | Solidifying JavaScript basics |                                     |
+|      4 |         7 | Loops & control structures    |                                     |
+
+[portfolio]: portfolio/README.md
+[twilio]: twilio/README.md

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -75,5 +75,6 @@ to create workshops and submit them to this directory.
 
 ## Contributing to the Workshops
 
-Interested in contributing to our workshops? [Look here](CONTRIBUTING.md).
-Beginners welcome!
+Interested in contributing to our workshops? [Look here](CONTRIBUTING.md). Our
+planned workshop progression is outlined in [`ARC.md`](ARC.md). Beginners
+welcome!


### PR DESCRIPTION
This pull request adds an initial version of our curriculum arc (or plan). This is super barebones (feedback appreciated!), but I figured it'd be best to at least get something down :smiley:. Closes #617.

Additionally, this outlines the tools hackers will use in our workshops, which closes #533 and closes #620.

In tandem with #633 and #573, this also closes #618. 