### PR TITLE
Unwrap code of conduct

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -2,34 +2,21 @@
 
 ## Why have a Code of Conduct?
 
-Hack Club's community includes people from many different backgrounds. The Hack
-Club contributors are committed to providing a friendly, safe, and welcoming
-environment for all, regardless of age, disability, gender, nationality, race,
-religion, sexuality, or similar personal characteristic.
+Hack Club's community includes people from many different backgrounds. The Hack Club contributors are committed to providing a friendly, safe, and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
 
-The first goal of the Code of Conduct is to specify a baseline standard of
-behavior so that people with different social values and communication styles
-can communicate effectively, productively, and respectfully.
+The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can communicate effectively, productively, and respectfully.
 
-The second goal is to provide a mechanism for resolving conflicts in the
-community when they arise.
+The second goal is to provide a mechanism for resolving conflicts in the community when they arise.
 
-The third goal of the Code of Conduct is to make our community welcoming to
-people from different backgrounds. Diversity is critical in order for us to
-build a thriving community; for Hack Club to be successful, it needs hackers
-from all backgrounds.
+The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical in order for us to build a thriving community; for Hack Club to be successful, it needs hackers from all backgrounds.
 
-With that said, a healthy community must allow for disagreement and debate. The
-Code of Conduct is not a mechanism for people to silence others with whom they
-disagree.
+With that said, a healthy community must allow for disagreement and debate. The Code of Conduct is not a mechanism for people to silence others with whom they disagree.
 
 ## Where does the Code of Conduct apply?
 
-If you join in or contribute to the Hack Club ecosystem in any way, you are
-encouraged to follow the Code of Conduct while doing so.
+If you join in or contribute to the Hack Club ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
 
-Explicit enforcement of the Code of Conduct applies to all official online Hack
-Club groups, in person meetings, and events including:
+Explicit enforcement of the Code of Conduct applies to all official online Hack Club groups, in person meetings, and events including:
 
 - The [GitHub projects](https://github.com/hackclub/)
 - The [Facebook Group](https://www.facebook.com/groups/1501083703514499/)
@@ -37,9 +24,7 @@ Club groups, in person meetings, and events including:
 - The `#hack-club` IRC channel on Freenode
 - Club Meetings
 
-Other Hack Club groups (such as conferences, meetups, and other unofficial
-forums) are encouraged to adopt this Code of Conduct. Those groups must provide
-their own moderators and/or working group (see below).
+Other Hack Club groups (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Those groups must provide their own moderators and/or working group (see below).
 
 ## Hacker Values
 
@@ -47,66 +32,40 @@ These are the values to which people in the Hack Club community should aspire.
 
 - Be friendly and welcoming
 - Be patient
-  - Remember that people have varying communication styles and that not everyone
-    is using their native language (meaning and tone can be lost in
-    translation).
+  - Remember that people have varying communication styles and that not everyone is using their native language (meaning and tone can be lost in translation).
 - Be thoughtful
-  - Productive communication requires effort. Think about how your words will be
-    interpreted.
+  - Productive communication requires effort. Think about how your words will be interpreted.
   - Remember that sometimes it is best to refrain entirely from commenting.
 - Be respectful
   - In particular, respect differences of opinion.
 - Be charitable
-  - Interpret the arguments of others in good faith, do not seek to disagree.
-  - When we do disagree, try to understand why.
+  - Interpret the arguments of others in good faith, do not seek to disagree. - When we do disagree, try to understand why.
 - Avoid destructive behavior:
-  - Derailing: stay on topic; if you want to talk about something else, start a
-    new conversation.
-  - Unconstructive criticism: don't merely condemn the current state of affairs;
-    offer—or at least solicit—suggestions as to how things may be improved.
+  - Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+  - Unconstructive criticism: don't merely condemn the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
   - Snarking (pithy, unproductive, sniping comments)
-  - Discussing potentially offensive or sensitive issues; this all too often
-    leads to unnecessary conflict.
-  - Microaggressions: brief and commonplace verbal, behavioral, and environmental
-    indignities that communicate hostile, derogatory or negative slights and
-    insults to a person or group.
+  - Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+  - Microaggressions: brief and commonplace verbal, behavioral, and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group.
 
-People are complicated. You should expect to be misunderstood and to
-misunderstand others; when this inevitably occurs, resist the urge to be
-defensive or assign blame. Try not to take offense where no offense was
-intended. Give people the benefit of the doubt. Even if the intent was to
-provoke, do not rise to it. It is the responsibility of _all parties_ to
-de-escalate conflict when it arises.
+People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of _all parties_ to de-escalate conflict when it arises.
 
 ## Unwelcome behavior
 
 These actions are explicitly forbidden in Hack Club spaces:
 
 - Insulting, demeaning, hateful, or threatening remarks.
-- Discrimination based on age, disability, gender, nationality, race, religion,
-  sexuality, or similar personal characteristic.
+- Discrimination based on age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
 - Bullying or systematic harassment.
 - Unwelcome sexual advances.
 - Provoking any of these.
 
 ## Moderation
 
-When you participate in [areas where the code of conduct
-applies](#where-does-the-code-of-conduct-apply), you should act in the spirit of
-the "Hacker values". If you conduct yourself in a way that is explicitly
-forbidden by the Code of Conduct, you will be warned and asked to stop. If you
-do not stop, you will be removed from our community spaces temporarily.
-Repeated, willful breaches of the Code of Conduct will result in a permanent
-ban. Staff and club leaders are held to a higher standard than other community
-members. Complaints about staff and club leaders actions must be handled using
-the reporting process below.
+When you participate in [areas where the code of conduct applies](#where-does-the-code-of-conduct-apply), you should act in the spirit of the "Hacker values". If you conduct yourself in a way that is explicitly forbidden by the Code of Conduct, you will be warned and asked to stop. If you do not stop, you will be removed from our community spaces temporarily. Repeated, willful breaches of the Code of Conduct will result in a permanent ban. Staff and club leaders are held to a higher standard than other community members. Complaints about staff and club leaders actions must be handled using the reporting process below.
 
 ## Reporting issues
 
-The Code of Conduct Working Group is a group of people that represent the Hack
-Club community. They are responsible for handling conduct-related issues. Their
-purpose is to de-escalate conflicts and try to resolve issues to the
-satisfaction of all parties. They are:
+The Code of Conduct Working Group is a group of people that represent the Hack Club community. They are responsible for handling conduct-related issues. Their purpose is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties. They are:
 
 | Name                | Slack Handle | Email                 |
 | ------------------- | ------------ | --------------------- |
@@ -114,31 +73,18 @@ satisfaction of all parties. They are:
 | Jonathan Leung      | @jonl        | jonathan@hackclub.com |
 | Zach Latta          | @zrl         | zach@hackclub.com     |
 
-If you encounter a conduct-related issue, you should report it to the Working
-Group using the process described below. **Do not** post about the issue
-publicly or try to rally sentiment against a particular individual or group.
+If you encounter a conduct-related issue, you should report it to the Working Group using the process described below. **Do not** post about the issue publicly or try to rally sentiment against a particular individual or group.
 
 - Mail conduct@hackclub.com
   - Your message will reach the Working Group.
   - Reports are confidential within the Working Group.
-  - Should you choose to remain anonymous then the Working Group cannot notify
-    you of the outcome of your report.
-  - You may contact a member of the group directly if you do not feel
-    comfortable contacting the group as a whole. That member will then raise the
-    issue with the Working Group as a whole, preserving the privacy of the
-    reporter (if desired).
-  - If your report concerns a member of the Working Group they will be recused
-    from Working Group discussions of the report.
-  - The Working Group will strive to handle reports with discretion and
-    sensitivity, to protect the privacy of the involved parties, and to avoid
-    conflicts of interest.
-- You should receive a response within 48 hours (likely sooner). (Should you
-  choose to contact a single Working Group member, it may take longer to receive
-  a response.)
-- The Working Group will meet to review the incident and determine what
-  happened.
-  - With the permission of person reporting the incident, the Working Group may
-    reach out to other community members for more context.
+  - Should you choose to remain anonymous then the Working Group cannot notify you of the outcome of your report.
+  - You may contact a member of the group directly if you do not feel comfortable contacting the group as a whole. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
+  - If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
+  - The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
+- You should receive a response within 48 hours (likely sooner). (Should you choose to contact a single Working Group member, it may take longer to receive a response.)
+- The Working Group will meet to review the incident and determine what happened.
+  - With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
   - The Working Group will reach a decision as to how to act. These may include:
     - Nothing.
     - A request for a private or public apology.
@@ -146,31 +92,20 @@ publicly or try to rally sentiment against a particular individual or group.
     - An imposed vacation (for instance, asking someone to abstain for a week
       from the Facebook Group or Slack).
     - A permanent or temporary ban from some or all Hack Club spaces.
-- The Working Group will reach out to the original reporter to let them know the
-  decision.
-- Appeals to the decision may be made to the Working Group, or to any of its
-  members directly.
+- The Working Group will reach out to the original reporter to let them know the decision.
+- Appeals to the decision may be made to the Working Group, or to any of its members directly.
 
-**Note that the goal of the Code of Conduct and the Working Group is to resolve
-conflicts in the most harmonious way possible.** We hope that in most cases
-issues may be resolved through polite discussion and mutual agreement. Bannings
-and other forceful measures are to be employed only as a last resort.
+**Note that the goal of the Code of Conduct and the Working Group is to resolve conflicts in the most harmonious way possible.** We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort.
 
-Changes to the Code of Conduct (including to the members of the Working Group)
-should be proposed by creating an issue [here] or making a pull request to this
-document.
+Changes to the Code of Conduct (including to the members of the Working Group) should be proposed by creating an issue [here] or making a pull request to this document.
 
 ## Summary
 
 - Treat everyone with respect and kindness.
 - Be thoughtful in how you communicate.
 - Don't be destructive or inflammatory.
-- If you encounter an issue, please mail
-  conduct@hackclub.com.
+- If you encounter an issue, please mail conduct@hackclub.com.
 
 ## Acknowledgments
 
-This was adapted from [Go's Code of Conduct]
-(https://github.com/golang/go/commit/aa487e66f869785837275ee20441a53888a51bb2).
-It is to be noted that many parts of Go's Code of Conduct is adopted from the
-Code of Conduct documents of the Django, FreeBSD, and Rust projects.
+This was adapted from [Go's Code of Conduct] (https://github.com/golang/go/commit/aa487e66f869785837275ee20441a53888a51bb2). It is to be noted that many parts of Go's Code of Conduct is adopted from the Code of Conduct documents of the Django, FreeBSD, and Rust projects.


### PR DESCRIPTION
This pull request removes the 80 character wrapping in the code of conduct, making it easier for contributors using the GitHub web interface to make changes.