### PR TITLE
Unwrap Slack onboarding guide

### DIFF
--- a/SLACK.md
+++ b/SLACK.md
@@ -1,70 +1,46 @@
 # <img src="img/slack_logo.png" alt="Slack" width="300px">
 
-Slack is an awesome tool for large group chats (check out their website at
-https://slack.com). Hack Club's Slack is the home of our community. We use it to
-ask each other questions, talk about the problems we run into (as members and
-club leaders), and hang out with each other.
+Slack is an awesome tool for large group chats (check out their website at https://slack.com). Hack Club's Slack is the home of our community. We use it to ask each other questions, talk about the problems we run into (as members and club leaders), and hang out with each other.
 
 ![Slack screenshot](img/slack_screenshot.png)
 
-If you're not already on Slack, let's get you into the community. Just keep
-reading for instructions on joining the community. After you've done that,
-you'll want to check out the Slack Field Guide ([click here](#field-guide)) for
-a handy reference on using the Slack.
+If you're not already on Slack, let's get you into the community. Just keep reading for instructions on joining the community. After you've done that, you'll want to check out the Slack Field Guide ([click here](#field-guide)) for a handy reference on using the Slack.
 
 # How To Join
 
-Open up https://slack.hackclub.com in a new tab and enter your email to get an
-invite from our handy bot.
+Open up https://slack.hackclub.com in a new tab and enter your email to get an invite from our handy bot.
 
 ![Get a Slack invite](img/slack_setup_1_invite.gif)
 
-If you head over to your email inbox, you should see an invite to join the
-Slack. Go ahead and click the `Join Hack Club` button in the email to create an
-account. It'll ask you to provide a username and password. This username is
-unique to Hack Club, so you can use usernames that are often taken on other
-sites (like `mary`). After you create an account, it'll take you to the main
-Slack interface (you can always get here by going to
-https://starthackclub.slack.com).
+If you head over to your email inbox, you should see an invite to join the Slack. Go ahead and click the `Join Hack Club` button in the email to create an account. It'll ask you to provide a username and password. This username is unique to Hack Club, so you can use usernames that are often taken on other sites (like `mary`). After you create an account, it'll take you to the main Slack interface (you can always get here by going to https://starthackclub.slack.com).
 
 ![Signing up for Slack](img/slack_setup_2_create_account.gif)
 
-If you haven't used Slack before, go ahead and click `Explore Slack` for a quick
-one minute tutorial that'll show you around the interface.
+If you haven't used Slack before, go ahead and click `Explore Slack` for a quick one minute tutorial that'll show you around the interface.
 
-Now to fill out our account details so other people in the community can get to
-know us better. Go ahead and go to `Hack Club > View Profile & Account > Edit
-Account` and fill everything out (make sure to set a profile picture!).
+Now to fill out our account details so other people in the community can get to know us better. Go ahead and go to `Hack Club > View Profile & Account > Edit Account` and fill everything out (make sure to set a profile picture!).
 
 ![Fill out profile](img/slack_setup_3_edit_profile.gif)
 
-Now for the final setup - introducing yourself! Go to the `#introductions`
-channel and introduce yourself with your name, where you're from, and something
-you're interested in.
+Now for the final setup - introducing yourself! Go to the `#introductions` channel and introduce yourself with your name, where you're from, and something you're interested in.
 
 Here's an example:
 
-> Hey everyone! I'm Mary from San Francisco. I'm a big fan of science fiction
-> books and want to learn to code :-).
+> Hey everyone! I'm Mary from San Francisco. I'm a big fan of science fiction books and want to learn to code :-).
 
 ![Introductions](img/slack_setup_4_introductions.gif)
 
-You'll find that people are generally pretty welcoming and eager to meet you
-:smiley:.
+You'll find that people are generally pretty welcoming and eager to meet you :smiley:.
 
 ![Introduction responses](img/slack_setup_5_introduction_responses.png)
 
-Congratulations! You're now all set up on the Slack. In addition to always being
-accessible at https://starthackclub.slack.com, Slack has great desktop and
-mobile apps available at https://slack.com/downloads. The most active members
-have the mobile app installed and we recommend new members install it.
+Congratulations! You're now all set up on the Slack. In addition to always being accessible at https://starthackclub.slack.com, Slack has great desktop and mobile apps available at https://slack.com/downloads. The most active members have the mobile app installed and we recommend new members install it.
 
 In the next section we'll go over a quick handy reference for using the Slack.
 
 ## Field Guide
 
-This field guide is intended as a quick channel reference for new and old
-members alike.
+This field guide is intended as a quick channel reference for new and old members alike.
 
 Below is a list of the channels that all members are in by default.
 


### PR DESCRIPTION
This change removes the 80 character wrapping in the Slack guide, making it easier for contributors using the GitHub web interface to make changes.