### PR TITLE
Add deprecated notice on Soccer

### DIFF
--- a/workshops/soccer/README.md
+++ b/workshops/soccer/README.md
@@ -1,5 +1,11 @@
 # Soccer
 
+**DEPRECATED**
+
+_**This workshop has been deprecated and is no longer maintained.**_
+
+---
+
 Short link to this workshop: https://workshops.hackclub.com/soccer
 
 Note to leaders running this workshop: we're replacing Soccer with [Dodge](../dodge/). We recommend running this in your clubs instead.


### PR DESCRIPTION
This pull request notifies the user that the Soccer workshop has been deprecated.

Adds:

> **DEPRECATED**
> 
> _**This workshop has been deprecated and is no longer maintained.**_
> 

to the top of the page.