### PR TITLE
Twine from sandbox to core

### DIFF
--- a/workshops/README.md
+++ b/workshops/README.md
@@ -46,8 +46,6 @@ You'll start off by building your first website and will eventually make your wa
 | [Platformer][platformer]                     | JavaScript & p5.js                       | A simple side-scrolling platformer game                                          | [@jkwok91][jkwok91]                                                                                                    |
 | [Collaborative Sketch][collaborative_sketch] | p5.js & Firebase                         | A real-time collaborative drawing pad                                            | [@jkwok91][jkwok91]                                                                                                    |
 | [Swiper][swiper]                           | Swift (requires OS X)                    | Make a fun and addicting iOS game using Swift and SpriteKit                      | [@zach-cmiel][zachcmiel]                                                                                               |
-| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
-
 
 ### Sandbox Workshops
 
@@ -62,6 +60,7 @@ _These workshops are either unfinished or untested._
 | [Maze][maze]                               | JavaScript                               | A "Scary Maze Game" clone                                                        | Hack Club staff                                                                                                        |
 | [Soccer][soccer]                           | JavaScript                               | A simple  soccer game                                                            | Hack Club staff                                                                                                        |
 | [Thugify][thugify]                         | JavaScript                               | Learn to dynamically modify webpages with jQuery                                 | [@nguyenbrian][nguyenbrian], [@JevinSidhu][JevinSidhu], [@uditdesai][uditdesai], and [@vaibhavyadaram][vaibhavyadaram] |
+| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
 
 ### Deprecated Workshops
 

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -46,6 +46,8 @@ You'll start off by building your first website and will eventually make your wa
 | [Platformer][platformer]                     | JavaScript & p5.js                       | A simple side-scrolling platformer game                                          | [@jkwok91][jkwok91]                                                                                                    |
 | [Collaborative Sketch][collaborative_sketch] | p5.js & Firebase                         | A real-time collaborative drawing pad                                            | [@jkwok91][jkwok91]                                                                                                    |
 | [Swiper][swiper]                           | Swift (requires OS X)                    | Make a fun and addicting iOS game using Swift and SpriteKit                      | [@zach-cmiel][zachcmiel]                                                                                               |
+| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
+
 
 ### Sandbox Workshops
 
@@ -60,7 +62,6 @@ _These workshops are either unfinished or untested._
 | [Maze][maze]                               | JavaScript                               | A "Scary Maze Game" clone                                                        | Hack Club staff                                                                                                        |
 | [Soccer][soccer]                           | JavaScript                               | A simple  soccer game                                                            | Hack Club staff                                                                                                        |
 | [Thugify][thugify]                         | JavaScript                               | Learn to dynamically modify webpages with jQuery                                 | [@nguyenbrian][nguyenbrian], [@JevinSidhu][JevinSidhu], [@uditdesai][uditdesai], and [@vaibhavyadaram][vaibhavyadaram] |
-| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
 
 ### Deprecated Workshops
 

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -46,6 +46,7 @@ You'll start off by building your first website and will eventually make your wa
 | [Platformer][platformer]                     | JavaScript & p5.js                       | A simple side-scrolling platformer game                                          | [@jkwok91][jkwok91]                                                                                                    |
 | [Collaborative Sketch][collaborative_sketch] | p5.js & Firebase                         | A real-time collaborative drawing pad                                            | [@jkwok91][jkwok91]                                                                                                    |
 | [Swiper][swiper]                           | Swift (requires OS X)                    | Make a fun and addicting iOS game using Swift and SpriteKit                      | [@zach-cmiel][zachcmiel]                                                                                               |
+| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
 
 ### Sandbox Workshops
 
@@ -60,7 +61,6 @@ _These workshops are either unfinished or untested._
 | [Maze][maze]                               | JavaScript                               | A "Scary Maze Game" clone                                                        | Hack Club staff                                                                                                        |
 | [Soccer][soccer]                           | JavaScript                               | A simple  soccer game                                                            | Hack Club staff                                                                                                        |
 | [Thugify][thugify]                         | JavaScript                               | Learn to dynamically modify webpages with jQuery                                 | [@nguyenbrian][nguyenbrian], [@JevinSidhu][JevinSidhu], [@uditdesai][uditdesai], and [@vaibhavyadaram][vaibhavyadaram] |
-| [Twine][twine]                             | Twine (web interface)                    | Build a text adventure game                                                      | [@remixz][remixz]                                                                                                      |
 
 ### Deprecated Workshops
 


### PR DESCRIPTION
This pull request is to fix the branch error from #952.

In this specifically, I moved the Twine workshop from core back to sandbox as an attempt to restart, so I won't have the same branch error.

Next commit will be moving the Twine workshop from sandbox to core.