### PR TITLE
Fix formatting of Firebase rules JSON

### DIFF
--- a/workshops/collaborative_sketch/README.md
+++ b/workshops/collaborative_sketch/README.md
@@ -75,6 +75,7 @@ firebase.initializeApp(config);
 After copying the code snippet above, head back to Firebase and select the `Auth` tab on the left-hand side. Select `SET UP SIGN-IN METHOD` from the top menu bar, and click `ADD DOMAIN`. Enter `preview.c9users.io` and click `ADD`.
 
 Next, go to the `Database` tab on the left-hand side. Within the `Database` tab, we're going to select `Rules`. Here we'll set database permissions for reading and writing to `true`.
+
 ```json
 {
     "rules": {


### PR DESCRIPTION
I've helped several people with this issue—because of the missing line, the code block is rendering as inline, which is confusing:

<img width="716" alt="screen shot 2017-03-30 at 4 13 06 pm" src="https://cloud.githubusercontent.com/assets/5074763/24524223/c99b2f3c-1563-11e7-981e-e5b73ba6a1e6.png">

This fixes it :)