### PR TITLE
Removing link to Molleindustria

### DIFF
--- a/workshops/dodge/README.md
+++ b/workshops/dodge/README.md
@@ -743,4 +743,4 @@ Thank you to the following people for making this workshop possible.
 - Lanea Zimmerman for the [Dirt Platformer Tiles](http://opengameart.org/content/dirt-platformer-tiles) tileset, which is used in the background image
 - The [Make Pixel Art](http://makepixelart.com) community for the [asteroid graphic](http://makepixelart.com/artists/anonymous/asteroid_33)
 - [p5.js](http://p5js.org/) community, for porting Processing to JS
-- [Molleindustria](http://www.molleindustria.org/), for the p5.play library
+- Molleindustria, for the p5.play library


### PR DESCRIPTION
Molleindustria is blocked for pornographic content in my district for some obvious reasons(look at their homepage). If it's blocked on ours for that reason, it might be blocked in other districts as well. It might be a good idea to remove the link to Molleindustria to remove the possibility of students getting in trouble for attempting to access this website, along with preventing the potential association of pornography to Hack Club.