### PR TITLE
Shorten workshop descriptions to two lines

### DIFF
--- a/workshops/dawgshop/README.md
+++ b/workshops/dawgshop/README.md
@@ -1,6 +1,6 @@
 ---
 name: The Dawgshop
-description: Learn to dynamically modify webpages with jQuery, dawg
+description: Dynamically modify your page with jQuery, dawg
 author: "@nguyenbrian, @JevinSidhu, @uditdesai, and @vaibhavyadaram"
 group: experimental
 order: 7

--- a/workshops/github_pages/README.md
+++ b/workshops/github_pages/README.md
@@ -1,6 +1,6 @@
 ---
 name: GitHub Pages
-description: Get your website online using GitHub's free hosting service
+description: Launch your website with GitHub's free hosting
 author: "@sethtrei"
 group: retired
 order: 3


### PR DESCRIPTION
All cards in a track on the Workshops page get taller if one description is extra long, so this PR modifies two descriptions to make all cards the same height.

Before:
<img width="783" alt="screen shot 2018-03-28 at 5 03 30 pm" src="https://user-images.githubusercontent.com/5074763/38056517-96d1d8de-32aa-11e8-9e99-6b5a7f29bc33.png">

After:
<img width="788" alt="screen shot 2018-03-28 at 5 04 05 pm" src="https://user-images.githubusercontent.com/5074763/38056511-94e913b6-32aa-11e8-8708-b95faaf6b9f8.png">
