### PR TITLE
Fix link to Workshops page on preface

### DIFF
--- a/workshops/preface/README.md
+++ b/workshops/preface/README.md
@@ -36,4 +36,4 @@ There's no shortage of opinions about the "right" or "best" way to learn how to 
 
 Regardless of your method, if you keep putting bricks on top of each other, it might take a long time but eventually you'll have a wall. This is where that faith mentioned earlier comes in handy. If you believe that with time and patience you can figure the whole coding thing out, in time you almost certainly will.
 
-_[Click me to go back to the workshop list](../)_
+_[Go back to the workshop list](https://hackclub.com/workshops)_


### PR DESCRIPTION
(Currently, clicking the link to the workshops list at the end of Preface shows the raw Markdown of the file.)

@zachlatta Viewing on GitHub, this will send people to our website, is that fine?