### PR TITLE
Update Wikibot workshop link

### DIFF
--- a/workshops/wikibot/README.md
+++ b/workshops/wikibot/README.md
@@ -156,7 +156,7 @@ Now that you know how to build a bot on WhatsApp, try sending notifications to y
 
 Here are some you can play with 👇
 
-- [QOTD API](https://favqs.com/api/qotd> (Gives you a new quote everyday)
+- [QOTD API](https://favqs.com/api/qotd) (Gives you a new quote everyday)
 - [Jokes API](https://08ad1pao69.execute-api.us-east-1.amazonaws.com/dev/random_joke) (Warning: jokes are **bad**)
 - [Chuck Norris](https://api.chucknorris.io/jokes/random) (Jokes on _American Rajinikanth_)
 - [Tonald Dump API](https://api.tronalddump.io/random/quote) (Stupid things Donald Trump has said)


### PR DESCRIPTION
Looks like there's a `>` instead of a `)` for closing a link. Oops!