### PR TITLE
Synth workshop

### DIFF
--- a/workshops/synth/README.md
+++ b/workshops/synth/README.md
@@ -4,6 +4,7 @@ description: "Let's make a synth pad with Tone.js"
 author: "cwalker"
 group: "start"
 order: 8
+launch: "https://repl.it/languages/html"
 ---
 
 # Synth Pad


### PR DESCRIPTION
simply adds a `launch` url to the workshop's metadata. Needed to test an "autofill" feature for the project submission form.