### PR TITLE
Fix link to Synth workshop author

### DIFF
--- a/workshops/synth/README.md
+++ b/workshops/synth/README.md
@@ -1,7 +1,7 @@
 ---
 name: "Synth"
 description: "Let's make a synth pad with Tone.js"
-author: "cwalker"
+author: "@polytroper"
 group: "start"
 order: 8
 launch: "https://repl.it/languages/html"


### PR DESCRIPTION
This change will properly link the author field of the Synth workshop on https://hackclub.com/workshops/synth/