### PR TITLE
Fix adding to list in Intro to Next.js workshop

### DIFF
--- a/workshops/nextjs_starter/README.md
+++ b/workshops/nextjs_starter/README.md
@@ -227,7 +227,7 @@ export default () => {
   const [newItem, setNewItem] = useState('')
   const changeNewItem = e => setNewItem(e.target.value)
   const addItem = () => {
-    setItems(list => list.push(newItem))
+    setItems(list => [...list, newItem])
     setNewItem('')
   }
   return (


### PR DESCRIPTION
The shopping list wasn't working as written (would produce "undefiend is not a function" error). I found the issue to be that the correct syntax is not `list.push(newItem)`, but instead `[...list, newItem]`