### PR TITLE
Update the link to the "Leader Instructions" page

### DIFF
--- a/workshops/rick_roll/README.md
+++ b/workshops/rick_roll/README.md
@@ -5,7 +5,7 @@ author: '@MatthewStanciu'
 group: starter
 ---
 
-*This workshop requires advance preparation by a club leader. If you are a club leader, [click here](https://workshops.hackclub.com/preview/master/rick_roll_leader) to view the preparation steps.*
+*This workshop requires advance preparation by a club leader. If you are a club leader, [click here](https://workshops.hackclub.com/preview/main/rick_roll_leader) to view the preparation steps.*
 
 [![](https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg)](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
 


### PR DESCRIPTION
The change of the default "master" branch name in github to "main" rendered the former link inaccessible as it lead to a 404 page.
Replacing "master" with "main" in the link leads to the actual page. (I checked)