### PR TITLE
Update where the COC applies

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -18,10 +18,9 @@ If you join in or contribute to the Hack Club ecosystem in any way, you are enco
 
 Explicit enforcement of the Code of Conduct applies to all official online Hack Club groups, in-person meetings, and events including:
 
+- The [Slack](https://hackclub.com/slack/)
+- The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), [Hack Night](https://hackclub.com/night/), & Zoom calls on Slack
 - The [GitHub projects](https://github.com/hackclub/)
-- The [Facebook Group](https://www.facebook.com/groups/1501083703514499/)
-- The [Slack](https://slack.hackclub.com)
-- The `#hack-club` IRC channel on Freenode
 - Club Meetings
 
 Other Hack Club groups (such as hackathons, conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Those groups must provide their own moderators and/or working group (see below).


### PR DESCRIPTION
We no longer use the Facebook group or IRC, but I think it’s important to note that the COC applies to our Events/Zoom calls as well.