### PR TITLE
📄 Bump MIT license year to 2021

### DIFF
--- a/MIT_LICENSE
+++ b/MIT_LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2020 Hack Club
+Copyright (c) 2015-2021 Hack Club
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Bump the MIT license year to 2021. Happy new year Hack Club!