### PR TITLE
Switch time statement in code

### DIFF
--- a/workshops/selenium/README.md
+++ b/workshops/selenium/README.md
@@ -344,10 +344,10 @@ tweetInputField = driver.find_element_by_xpath(
 
 tweetInputField.send_keys(tweet)
 
-time.sleep(1)
-
 tweetButton = driver.find_element_by_xpath(
   '/html/body/div/div/div/div[2]/main/div/div/div/div/div/div[2]/div/div[2]/div[1]/div/div/div/div[2]/div[4]/div/div/div[2]/div[3]')
+  
+time.sleep(1)
 
 tweetButton.click()
 


### PR DESCRIPTION
In the demo video, `time.sleep(1)` comes before `tweetButton.click()`, but it was the other way around on the workshop page. I got an error message when I copy/pasted the code from the workshop page. Therefore, I concluded that the code in the demo video was correct and the code on the page was not.

<!---
Hey! FYI: The Workshop Bounty program has now ceased. Other contributions are more than welcome as always, though <3

If you are making a resubmission please check that your PR is eligible here: https://github.com/hackclub/hackclub/issues/1597 

The eligibility details are outlined here: https://hackclub.slack.com/archives/C01AA5ECPJP/p1608951091458300
-->
