### PR TITLE
This workshop's API is deprecated  and no longer works

### DIFF
--- a/workshops/not_hotdog/README.md
+++ b/workshops/not_hotdog/README.md
@@ -4,7 +4,9 @@ description: 'Build a basic hot dog classifier using the Clarifai API for Python
 author: '@harrisbegca'
 begin: 'https://repl.it/repls/GullibleAccomplishedCables'
 ---
-<!--- Needs to be updated or removed-->
+
+*Note: the API this workshop uses is deprecated, so this workshop is out of date and no longer on the workshops site. See https://github.com/hackclub/hackclub/pull/1695 for more info. If you would like to help get this workshop back up, please let me know on Slack (@matthew).*
+
 ## Part 1: Background
 
 You may or may not already be familiar with the popular TV show **Silicon Valley**, in which a character, Jian-Yang, promises to help build an app that identifies different types of food. While the idea is promising, Jian-Yang clearly misunderstands and makes, well, [this](https://www.youtube.com/watch?v=pqTntG1RXSY).

--- a/workshops/not_hotdog/README.md
+++ b/workshops/not_hotdog/README.md
@@ -4,7 +4,7 @@ description: 'Build a basic hot dog classifier using the Clarifai API for Python
 author: '@harrisbegca'
 begin: 'https://repl.it/repls/GullibleAccomplishedCables'
 ---
-
+<!--- Needs to be updated or removed-->
 ## Part 1: Background
 
 You may or may not already be familiar with the popular TV show **Silicon Valley**, in which a character, Jian-Yang, promises to help build an app that identifies different types of food. While the idea is promising, Jian-Yang clearly misunderstands and makes, well, [this](https://www.youtube.com/watch?v=pqTntG1RXSY).


### PR DESCRIPTION
I did the Not Hotdog ML Clarifai workshop and it did not work. I am almost certain that it does not work because the api the workshop uses is deprecated. The new Clarifai API looks more complicated, and from looking at the docs I don't think it will be 16 lines of code for the same results. I thought about just making this an issue, but since its only specific to this workshop, I just decided to tell y'all here.

[New Clarifai API] (https://github.com/Clarifai/clarifai-python-grpc)
[Old API(that the workshop is based on)](https://github.com/Clarifai/clarifai-python)

<!---
Hey! FYI: The Workshop Bounty program has now ceased (including resubmissions). 

Other contributions are more than welcome as always, though <3
-->

