### PR TITLE
Fix typo in description for Password Generator workshop

### DIFF
--- a/workshops/password_generator/README.md
+++ b/workshops/password_generator/README.md
@@ -1,6 +1,6 @@
 ---
 name: 'Password Generator'
-description: 'Build a password genertor tool with HTML, CSS, and JavaScript'
+description: 'Build a password generator tool with HTML, CSS, and JavaScript'
 author: '@HariOm987'
 img: https://cloud-nu1ftbbxy.vercel.app/0sample-demo.png
 ---


### PR DESCRIPTION
The description had a typo that said genertor instead of generator (the a was missing).