### PR TITLE
Add alt text to all workshops

### DIFF
--- a/workshops/collaborative_sketch/README.md
+++ b/workshops/collaborative_sketch/README.md
@@ -8,7 +8,7 @@ author: '@jkwok91'
 
 | What you'll build       |
 | ----------------------- |
-| ![](img/final_demo.gif) |
+| ![Smiley face being drawn on 2 screen simultaneously](img/final_demo.gif) |
 
 _We recommend going through this workshop in Google Chrome._
 
@@ -84,7 +84,7 @@ Next, go to the `Database` tab on the left-hand side. Change the Database type b
 
 Click `Publish` to save your changes. You should see this warning at the top of your page -- don't worry about it:
 
-![](img/firebase_warning.png)
+![Red warning message with caution icon](img/firebase_warning.png)
 
 We'll now head back to our `script.js` file. Below the Firebase configuration, we'll add a variable `pointsData` that we can use to access Firebase.
 

--- a/workshops/colorful_grammar/README.md
+++ b/workshops/colorful_grammar/README.md
@@ -182,7 +182,7 @@ The beauty of this workshop is that there are endless ways you can go about crea
 
 We’re going to be creating our color with the [HSL (Hue, Saturation, Luminosity) color system](http://thenewcode.com/61/An-Easy-Guide-To-HSL-Color). If you’re not familiar with it, all you need to understand for this demo is that the HSL system uses a color wheel, and you identify a color according to its position on the color wheel in degrees. Also important to note is that colors start a new cycle once you pass 360°. Just like a 60° angle looks the same as a 420 (360 + 60)° angle, 60° on the HSL color system is the same color as 420°: yellow.
 
-![](img/hsl-color-wheel.PNG)
+![Color wheel divided into 6 equal parts](img/hsl-color-wheel.PNG)
 
 Because we can simply identify a color with a number, one way we can process our data is by adding up the frequency of each type of word. Using the WordPOS library, getting the total number of word type is as simple as `types.[type].length`; for example, `types.verbs.length`.
 

--- a/workshops/dodge/README.md
+++ b/workshops/dodge/README.md
@@ -8,7 +8,7 @@ author: '@MaxWofford'
 
 | What you'll build       |
 | ----------------------- |
-| ![](img/final_demo.gif) |
+| ![brown objects falling from the sky while dinosaur moves horizontally across the screen](img/final_demo.gif) |
 
 Links to a live demo and the final code below. This workshop should take around 1 hour and 15 minutes.
 
@@ -39,7 +39,7 @@ Just as we've done previously, we're going to be building this project in Repl.i
 
 Go ahead and spin up a new [HTML repl](https://repl.it/languages/html) before continuing.
 
-![](img/html_repl.png)
+![user interface of a code editor with text](img/html_repl.png)
 
 Our project's code is going to be divided into two files: `index.html` (the HTML code) and `script.js` (the JavaScript code). The HTML file will tell the browser about the game's existence and how to display it on the page. The JavaScript file will tell the browser how to actually run the game.
 
@@ -538,21 +538,21 @@ We're providing the following images and have already uploaded them to an image 
 
 > | **Player**                        |
 > | --------------------------------- |
-> | ![](img/prophet_orpheus.png)      |
+> | ![white dinosaur sprite](img/prophet_orpheus.png)      |
 > | `https://i.imgur.com/N5uCbDu.png` |
 
 <br/>
 
 > | **Enemy**                         |
 > | --------------------------------- |
-> | ![](img/asteroid.png)             |
+> | ![brown asteroid](img/asteroid.png)             |
 > | `https://i.imgur.com/OdL0XPt.png` |
 
 <br/>
 
 > | **Background**                    |
 > | --------------------------------- |
-> | ![](img/background.png)           |
+> | ![night sky with stars](img/background.png)           |
 > | `https://i.imgur.com/aKQOg3G.png` |
 
 <br/>
@@ -694,7 +694,7 @@ function setup() {
 
 In GIF of what we're aiming for, you'll notice that the asteroid (the `enemy`) is spinning.
 
-![](img/final_demo.gif)
+![White dinosaur moving horizontally while brown asteroids fall from the sky](img/final_demo.gif)
 
 This is actually quite easy to implement using p5.play. The [`Sprite`](http://p5play.molleindustria.org/docs/classes/Sprite.html) class in p5.play has an attribute called [`rotationSpeed`](http://p5play.molleindustria.org/docs/classes/Sprite.html#prop-rotationSpeed), which we can set to have p5.play rotate the sprite every time `draw()` is called.
 

--- a/workshops/find_bigfoot/README.md
+++ b/workshops/find_bigfoot/README.md
@@ -55,7 +55,7 @@ So now you have to put an **image** of him into your game, like you did in the [
 
 When you're done, you should see Bigfoot in the live preview, like this:
 
-![](img/bigfoot_image.png)
+![A human-like figure on a mostly blank webpage](img/bigfoot_image.png)
 
 And the `index.html` file looks like this:
 
@@ -73,17 +73,17 @@ And the `index.html` file looks like this:
 
 A game needs interaction in order to be a game, so let's display a pop-up box whenever the player clicks on Bigfoot, like this:
 
-![](img/bigfoot_popup.gif)
+![Popup with text saying "Wohoo, you win! You found bigfoot!"](img/bigfoot_popup.gif)
 
 How can you do that?
 
 One of the most important skills towards becoming an independent hacker is knowing how to Google things when stuck. So let's start by Googling "[HTML handle click](https://www.google.com/search?q=html+handle+click)":
 
-> ![](img/google_html_handle_click.png)
+> ![List of search results for the query HTML handle click](img/google_html_handle_click.png)
 
 Clicking the first link takes you [here](http://www.w3schools.com/jsref/event_onclick.asp):
 
-> ![](img/w3schools_onclick.png)
+> ![Example showing a code snippet, description, and button to try it yourself](img/w3schools_onclick.png)
 
 Aha! It looks like whenever you put `onclick="myFunction()"` on a tag such as `button` or `img`, it executes the [**JavaScript**](http://www.w3schools.com/js/) code you put in the quotes whenever that tag is clicked on.
 
@@ -95,11 +95,11 @@ For one moment:
 
 We want our JavaScript code to display a pop-up box saying you've won. So now let's Google "[JavaScript pop-up box](https://www.google.com/search?q=javascript+popup+box)":
 
-> ![](img/google_javascript_popup_box.png)
+> ![List of search results for the query 'javascript popup box'](img/google_javascript_popup_box.png)
 
 The first link takes you [here](http://www.w3schools.com/js/js_popup.asp):
 
-> ![](img/w3schools_popup.png)
+> ![Example with code snippet, description, and button to try it yourself](img/w3schools_popup.png)
 
 It looks like when you run `alert("I am an alert box!");` it opens a pop-up box showing the text inside the quotes. So if we put 2 and 2 together, our `img` tag should look like this:
 
@@ -144,7 +144,7 @@ That must be because we took him out of his natural habitat. You see, normally B
 
 When you are making your own projects, you won't have workshops telling the solution to every step. So this time, let's practice your Googling skills and see if you can figure out how to set that background image without being told the solution! After adding the background image, the live preview looks like this:
 
-![](img/bigfoot_background.png)
+![Image of a forest scene with dense branches](img/bigfoot_background.png)
 
 When you are done, or if you are simply really stuck, we've included a sample solution below. (But there are other ways to add the background image, so if your solution doesn't match mine, that's OK.)
 
@@ -168,7 +168,7 @@ There are several ways to add the background image. Here is one way:
 
 That's much better! But the top left corner is a pretty boring place to hide Bigfoot. Can you figure out how to set Bigfoot's **position** to somewhere else? This one is harder, and may take some trial and error, but it's really worth the effort to see if you can figure it out yourself. Afterwards, Bigfoot's position will be somewhere in the middle of the forest, rather than the top left corner, like this:
 
-![](img/bigfoot_position.png)
+![image of a forest scene with dense branches and a small figure hidden in the middle](img/bigfoot_position.png)
 
 OK, got it working? If you need help, try asking your neighbor or workshop leader for hints.
 
@@ -178,11 +178,11 @@ Let's walk through the steps of one way of solving this.
 
 Google "[HTML position](https://www.google.com/search?q=html+position)".
 
-> ![](img/google_html_position.png)
+> ![List of search results for the query 'html position'](img/google_html_position.png)
 
 The first link takes you [here](http://www.w3schools.com/cssref/pr_class_position.asp):
 
-> ![](img/w3schools_position.png)
+> ![Code example for positioning an html element](img/w3schools_position.png)
 
 It has some CSS code showing how to "position an `<h2>` element":
 

--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -10,7 +10,7 @@ Prophet Orpheus, [our mascot](https://hackclub.com/workshops/orpheus), is here t
 
 It will look something like this:
 
-![](img/dino_site.png)
+![dinosaur reading a book](img/dino_site.png)
 
 Here's the [live demo][final_live_demo] and [final code][final_code] (see `index.html` and `style.css`).
 
@@ -27,7 +27,7 @@ This workshop should take around 45 minutes.
 
 To get started, go to [https://repl.it/languages/html](https://repl.it/languages/html). Your coding environment will spin up in just a few seconds!
 
-![](img/html_repl.png)
+![Text inside a code editor](img/html_repl.png)
 
 ## Part II: The HTML File
 
@@ -37,7 +37,7 @@ HTML stands for Hypertext Markup Language. Every website from the New York Times
 
 You should have the `index.html` file open, and a bunch of text with `<` & `>` symbols. That's HTML!
 
-![](img/html_repl.png)
+![Text inside a code editor](img/html_repl.png)
 
 Repl.it gives us some code to start out with, but we're going to start from scratch. Go ahead and delete everything in the `index.html` file then **type** in the following. **DO NOT COPY AND PASTE.**
 
@@ -53,7 +53,7 @@ This structure is common to all HTML pages. In fact, you can take a look for you
 
 <!-- Source https://developers.google.com/web/tools/chrome-devtools/inspect-styles/imgs/elements-panel.png -->
 
-![](img/elements-panel.png)
+![Inspect element panel containing html and css styles for a website](img/elements-panel.png)
 
 Before proceeding, we'll briefly go over what our template means.
 
@@ -65,15 +65,15 @@ HTML works by storing information inside tags. `<html></html>` is an example of 
 
 Let's check out what our HTML file looks like in Live Preview! To do this, click on the **Run** button above the editor or press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (<kbd>Command</kbd> + <kbd>Enter</kbd> on Mac).
 
-![](img/run.png)
+![A green button and gray button side by side](img/run.png)
 
 From there, the live preview to the right of the editor should show what your website looks like. If you want to view it in a new tab, the URL above the website preview is the live URL for your website
 
-![](img/url.png)
+![Image of a url for a website](img/url.png)
 
 You can also open the external live preview by clicking the icon that looks like a box with an arrow. This will open live preview in a new tab at the aforementioned URL
 
-![](img/preview.gif)
+![Launching the website in a new page](img/preview.gif)
 
 As you can see, the page is blank. This is because we haven't added anything to the `body` section yet. Let's add some content!
 
@@ -141,7 +141,7 @@ Go ahead and add this into your `index.html` now. I put my picture before my hea
 </html>
 ```
 
-![](img/no_css.png)
+![dinosaur reading a book and text describing it below](img/no_css.png)
 
 Remember, you need to **Run** your program every time you want to see your updated website.
 
@@ -157,7 +157,7 @@ While HTML oversees the content and the way it's structured, CSS is how you'll s
 
 We already have an `style.css` in the file tree and this is called an external style sheet because the CSS file is external to the HTML file (i.e., the stylesheet is not inside the HTML file).
 
-![](img/index_css.png)
+![Three files in a list](img/index_css.png)
 
 Although we have a CSS file, until we explicitly tell the HTML file to use the CSS file, it will not use it. We must explicitly link the CSS file in the HTML. We'll do this by typing the following into the head of `index.html` (between `<head>` and `</head>`), because the head is where we tell information about the page to the browser.
 
@@ -236,7 +236,7 @@ body {
 
 Now be sure to **Run** to get the most recent version of your website. Ah, it is truly beautiful to behold.
 
-![](img/celebrate_harry_potter.gif)
+![Children celebrating](img/celebrate_harry_potter.gif)
 
 ## Part IV: Publishing
 
@@ -244,21 +244,21 @@ To actually save your website and be able to come back to it in the future you'l
 
 To create an account, click on the sign up prompt in the top right corner.
 
-![](img/signup.png)
+![Input fields for logging in](img/signup.png)
 
 Once you've filled out the fields (or signed up with another account), go ahead and click on the link they send you by email
 
-![](img/email.png)
+![Confirmation email asking for email verification](img/email.png)
 
 Now that you have your account set up, all you need to do to change the name of your repl is click on the pencil next to it.
 
-![](img/edit_name.png)
+![Edit button for changing the name of a project](img/edit_name.png)
 
 Once you're happy with the name you've given it, press <kbd>Enter</kbd> to confirm your changes (or <kbd>Escape</kbd> to cancel your name change)
 
 And just like that your website is now published at the domain `PROJECTNAME--USERNAME.repl.co` (that's two dashes before your username) on the internet for all your friends to see!
 
-![](img/celebrate_rush_hour.gif)
+![Two people singing and moving side to side in a car](img/celebrate_rush_hour.gif)
 
 ## Part V: Hacking
 

--- a/workshops/platformer/README.md
+++ b/workshops/platformer/README.md
@@ -8,7 +8,7 @@ author: '@jkwok91'
 
 | What you'll build       |
 | ----------------------- |
-| ![](img/final_demo.gif) |
+| ![Square particles moving in a game](img/final_demo.gif) |
 
 _We recommend going through this workshop in Google Chrome._
 
@@ -293,7 +293,7 @@ if (firstGroundSprite.position.x <= camera.position.x - width / 2) {
 
 Save and refresh live preview. Hm, does something look funny to you? Specifically, how the first ground sprite is just blipping off the left edge instead of smoothly sliding off?
 
-![](img/scrolling_sprites.gif)
+![Text and diagrams describing the sprites position](img/scrolling_sprites.gif)
 
 This is an issue of not properly offsetting the sprite. Remember that the position of a sprite is at its center, so we must edit our conditional to include this offset. It should now read:
 
@@ -723,7 +723,7 @@ It's time to add in our sprite images! This exercise is left to the user.
 
 Make sure you're logged into your Repl.it account and, if you want to, go ahead and change the name of your repl by clicking on the pencil next to it.
 
-![](img/edit_name.png)
+![Edit button for changing project name](img/edit_name.png)
 
 Your game is now live and playable on `REPL_NAME--USERNAME.repl.co`!!
 

--- a/workshops/rick_roll/README.md
+++ b/workshops/rick_roll/README.md
@@ -7,7 +7,7 @@ group: starter
 
 _This workshop requires advance preparation by a club leader. If you are a club leader, [click here](https://workshops.hackclub.com/preview/main/rick_roll_leader) to view the preparation steps._
 
-[![](https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg)](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
+[![Person with an open mouth, singing](https://img.youtube.com/vi/dQw4w9WgXcQ/0.jpg)](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
 
 Rickrolling has been around since the early days of the Internet. But have you ever wanted to take rickrolling to the next level, into the realm of phones? That’s what you’re going to do today. In this workshop, you’re going to build a Node.js web app that calls your phone and rickrolls you.
 
@@ -58,7 +58,7 @@ Instead of offering a private key in plain text, Nexmo saves private keys in a f
 
 Obtain the `private.key` file from your club leader and download it to your computer. Then, upload the file to repl.it by clicking on the three dots at the top left of your screen and clicking “Upload file”.
 
-![](img/upload-file.jpg)
+![Dropdown menu for uploading files in repl.it](img/upload-file.jpg)
 
 Once your `private.key` file is uploaded, you’re all set to start making calls!
 

--- a/workshops/rick_roll_leader/README.md
+++ b/workshops/rick_roll_leader/README.md
@@ -14,24 +14,24 @@ _Note: you'll be required to provide a valid email address and phone number in o
 
 ## Signing up for Nexmo
 
-![](img/nexmo.png)
+![Creating customer journeys through conversations. Engaging experiences that move with your customers. Try it free. Contact Sales.](img/nexmo.png)
 
 Visit [Nexmo's website](https://nexmo.com) and sign up by clicking on "Try it free".
 
-![](img/signup.png)
+![Sign up up form with fields for name, email, and password](img/signup.png)
 
 Fill out the signup form with the requested information.
 
-![](img/email-verify-notification.png)
-![](img/email-verify-email.png)
+![Verification letter asking to verify your email](img/email-verify-notification.png)
+![Verification letter asking to verify your email](img/email-verify-email.png)
 
 You'll be sent a verification email. This may take a few minutes to arrive, and sometimes it'll be in your spam folder, so keep that in mind. Verify your email address once you receive the email.
 
-![](img/phone-verification.png)
+![Request message for phone number verification](img/phone-verification.png)
 
 Once you verify your email, you'll be taken to another page which asks you to input a phone number for extra verification. Once you enter your phone number, you'll receive a text message with a verification code that you need to input.
 
-![](img/dashboard.png)
+![Dashboard showing API keys and account balance](img/dashboard.png)
 
 Once you verify your phone number, you should be redirected to the Nexmo dashboard. You should also notice that you have $2 in free credit. Calls cost 1.39 cents per minute, so plan accordingly. If you lead a large club, you may want to consider adding some extra money to your account to ensure your funds don't run out during your meeting.
 
@@ -39,7 +39,7 @@ Copy your API key and API secret and store them somewhere where you can easily r
 
 ## Creating an application
 
-![](img/voice.png)
+![Webpage prompting user to name the new application](img/voice.png)
 
 Navigate to "Voice –> Getting started" in the sidebar. You should be taken to this page, where you'll be able to create an application by typing in the name of your application. Once you click on "Create application", you should be prompted to download a file called `private.key`. Make sure you download this file—you'll need it for when your club members authenticate with your app. Nexmo stores application private keys in this file instead of storing them in plain text.
 
@@ -49,7 +49,7 @@ You'll also notice that you're given a new Application ID once you create your a
 
 By default, all calls using your Nexmo API credentials will come from the phone number you provided during signup. You'll have to share this phone number with your club members during the workshop. If you're okay with this, you don't need to complete this step. But if you don't want to share your personal phone number, you'll need to use a Nexmo virtual number instead.
 
-![](img/number.png)
+![Data table for creating a new virtual phone number](img/number.png)
 
 Luckily, your Nexmo account comes with a free virtual number for your first month. To find it, navigate to "Numbers –> Your numbers". Click on the number to copy it, then save it somewhere where you can easily retrieve it.
 

--- a/workshops/sound_galaxy/README.md
+++ b/workshops/sound_galaxy/README.md
@@ -6,7 +6,7 @@ author: '@MatthewStanciu'
 
 Sound visualization is one of the coolest things that modern-day web development tools have made accessible. There’s something surreal and indescribably satisfying about _seeing_ the sounds around you on your screen and somehow understanding what you’re seeing.
 
-![](img/final-demo.GIF)
+![Colorful particles traveling vertically down the screen](img/final-demo.GIF)
 
 In this workshop, you’re going to create a galaxy out of shimmering particles that expand and move based on microphone input, in less than 50 lines of code.
 
@@ -159,7 +159,7 @@ function draw() {
 
 If you run your repl now, you should see this:
 
-![](img/draw.png)
+![Colorful particles randomly scattered on a white canvas](img/draw.png)
 
 Nice! We've just given life to our particles! If you want to make your canvas look more like space, you can add
 

--- a/workshops/splatter_paint/README.md
+++ b/workshops/splatter_paint/README.md
@@ -8,7 +8,7 @@ author: '@MatthewStanciu'
 
 One of the most common myths about coding among people who are first learning to code is that coding mostly consists of sitting in a dark room all day writing ~Algorithms~ in a black terminal window with green text, solving complex mathematical equations, and generally being a genius. You’re going to crush this myth in this workshop by making crazy, colorful splatter paint right in your web browser, in only 20 minutes.
 
-![](img/final-demo.png)
+![Colorful patterns of dots and lines on a canvas](img/final-demo.png)
 
 [Final code](https://repl.it/@TechBug2012/splatter-paint#index.html)
 <br/>
@@ -101,7 +101,7 @@ function onMouseMove(event) {
 
 Instead of using the more common hexademical or RGB color systems, Paper.js uses the HSB color system, which uses angles on a color wheel to describe color. In the HSB color system, 0 = 0° = red, and `360*n`° is also red.
 
-![](img/hsb-color-wheel.PNG)
+![Color wheel in which each color is assigned a degree value](img/hsb-color-wheel.PNG)
 
 (If you’re interested in learning more about the HSB color system, check out [this fantastic explanation](https://learnui.design/blog/the-hsb-color-system-practicioners-primer.html))
 
@@ -150,23 +150,23 @@ canvas {
 
 If you run your repl again, you should notice that your red circles are now filling the entire screen. Woohoo!
 
-![](img/red-circles.JPG)
+![Random pattern formed by red circles](img/red-circles.JPG)
 
 ## Making it splattery
 
 We’re getting somewhere, but this still doesn’t feel very splattery.
 
-![](img/real-splatter-paint.JPG)
+![colorful paint randomly splattered on a canvas](img/real-splatter-paint.JPG)
 
 Part of what makes splatter paint so fun to create and look at is the chaotic randomness of everything on the canvas. So, if you want to get your website as close to splatter paint as possible, the best way to do it is to introduce some randomness.
 
 Change the radius of your circles from `10` to `Math.round(Math.random() * 25) + 5`. This makes the radius a random number between 5 and 30. Then run the repl again.
 
-![](img/random-radius.JPG)
+![Circles with large radii forming a random pattern on a canvas](img/random-radius.JPG)
 
 Not bad, but it feels sort of mashed together, doesn’t it? Maybe we can make each circle unique by making it a different color than the last. Try changing the hue from `0` to `event.count * 3`. Run the repl and see what happens.
 
-![](img/rainbow-colors.JPG)
+![Rainbow assortment of circles of various sizes on a canvas](img/rainbow-colors.JPG)
 
 `event.count * 3` creates a rainbow effect by setting the hue on each circle to the total number of times a circle has been drawn multiplied by 3, which jumps around the HSB color wheel. And it looks great!
 

--- a/workshops/teachable_machine/README.md
+++ b/workshops/teachable_machine/README.md
@@ -18,17 +18,17 @@ Machine learning models are trained with large amounts of data that attempt to �
 
 Get started by visiting [teachablemachine.withgoogle.com](https://teachablemachine.withgoogle.com) and clicking on “Get Started”. You should be greeted with the option to create an image, audio, or pose project. For now, pick “Image Project”.
 
-![](img/homepage.JPG)
+![A row of three example projects including an image of a dog, audio waves, and a person posing](img/homepage.JPG)
 
-![](img/imageproject.PNG)
+![Webpage featuring a category for Class, Training, and Preview](img/imageproject.PNG)
 
 Rename “Class 1” and “Class 2” to “me” and “me with [some object]”.
 
-![](img/renameclass.GIF)
+![Renaming a field by entering text in a box](img/renameclass.GIF)
 
 Next, turn on your webcam for each class and click “Hold to Record” until you have a few hundred image samples recorded. You want to take as many pictures and capture as many angles, positions, etc. as you possibly can. The more data you have, the better your model will learn the difference between the two sets of data.
 
-![](img/imagesamples.PNG)
+![A row of images of a person and a row of images of a person with a phone](img/imagesamples.PNG)
 
 Once you feel you’ve recorded enough samples, click on “Train Model”. The time it takes to train the model will vary depending on how many image samples you gave it, but it usually takes somewhere around 30 seconds.
 
@@ -36,13 +36,13 @@ Once your model is trained, a preview should appear. Try it out! If it’s shaky
 
 Here’s what mine looks like:
 
-![](img/model.GIF)
+![A person holding a phone](img/model.GIF)
 
 ## Exporting your model
 
 Teachable Machine will host your model on their servers, so you can use it in any project you want. To upload your model to Teachable Machine’s servers, click on “Export Model”, then click “Upload my model” once the window pops up. After a few seconds, you should see a link to your model available under “Your sharable link:”
 
-![](img/uploadedmodel.PNG)
+![A modal displaying a shareable url for the project](img/uploadedmodel.PNG)
 
 (FYI: if you’re interested in seeing the raw data of your model, copy the link to the model and paste it in your URL bar with `model.json` at the end)
 
@@ -58,13 +58,13 @@ Now it’s time to add your Teachable Machine model to your own project!
 
 Run the repl, then open your website in a new tab by clicking the icon at the top right. Once you click “Start” and give the site access to your webcam, you should see your model!
 
-![](img/finalmodel.PNG)
+![Person holding a phone with text identifying the state of action](img/finalmodel.PNG)
 
 ## Hacking
 
 Congratulations! You’ve just trained a machine learning model directly in your browser without writing any code. But your journey is far from over—there are endless ways you can take this project further. Did you notice the “Add a class” button below your two original classes?
 
-![](img/add-a-class.PNG)
+![A row of images of a person holding a phone and an option to "Add a Class" at the bottom](img/add-a-class.PNG)
 
 You can train this model with as many classes as you want! Try and see how far you can take it—you, you + phone, you + water bottle, you + phone + water bottle, etc. Go crazy.
 

--- a/workshops/wikibot/README.md
+++ b/workshops/wikibot/README.md
@@ -10,7 +10,7 @@ A few months ago, I'd started making chatbots on [Telegram](https://t.me)—I'd 
 
 A week ago, I saw that [Twilio](https://twilio.com) had an official WhatsApp API. 30 minutes later, I made a [Wikipedia bot on WhatsApp](https://wikibot.4ty2.fun) 👇
 
-![](img/demo.png)
+![Text message describing the term Wikipedia](img/demo.png)
 
 This is a workshop to help you make a something like this, and make your own chatbots on WhatsApp, in just 30 minutes 🎓
 
@@ -18,21 +18,21 @@ This is a workshop to help you make a something like this, and make your own cha
 
 First, Sign up for [Twilio](https://www.twilio.com/try-twilio)—it's free and you won't need a credit card 💳
 
-![](img/twilio_signup.png)
+![Input fields for signing up for an account](img/twilio_signup.png)
 
 Once you're done verifying your phone number, select Products > Programmable SMS and then continue to name your project.
 
-![](img/twilio_products.png)
+![Project creation interface showing 4 boxes](img/twilio_products.png)
 
 Feel free to skip steps for adding teammates—you won't need that for now.
 
 You must now take note of some authentication keys you'll need for building the WhatsApp bot 👇
 
-![](img/auth_token.png)
+![Project dashbaord with authorization tokens highlighted](img/auth_token.png)
 
 The final step—[set up your WhatsApp Sandbox](https://www.twilio.com/console/sms/whatsapp/sandbox)—choose any number, and join your sandbox following instructions on the page.
 
-![](img/whatsapp_sandbox.png)
+![Settings page with information on setting up](img/whatsapp_sandbox.png)
 
 …and you're done with credential setup! Don't worry, that was the toughest part of this tutorial 😛
 
@@ -51,11 +51,11 @@ You can see, this environment already has dependencies installed, and an `expres
 
 Let's go back to the [WhatsApp Sandbox](https://www.twilio.com/console/sms/whatsapp/sandbox), and put in a webhook URL for incoming messages.
 
-![](img/sandbox_webhook_url.png)
+![Image of a webhook URL](img/sandbox_webhook_url.png)
 
 This URL must be what you see on the preview panel of your [repl.it](http://repl.it) project + `/incoming`
 
-![](img/replit_url.png)
+![Code in a code editor](img/replit_url.png)
 
 We can now finally read messages that are sent to the bot. Add a simple `console.log()` in your webhook handler 👇
 
@@ -67,7 +67,7 @@ app.post('/incoming', (req, res) => {
 
 When you send a message to your bot, you should be able to see something like this in your repl.it console 👨‍💻
 
-![](img/app_running.png)
+![Console output of a program running](img/app_running.png)
 
 Building an Echo bot would look something like this, using `twiml` to write a message 👇
 


### PR DESCRIPTION
This PR adds alt text to the following workshops 
 - Colorful Grammar
 - Rickroll
- Rickroll Leader
 - Sound Galaxy
-  Splatter Paint
-  Teachable Machine
-  Collaborative sketch
  - Dashboard (except this one bc it already had alt text)
-  Dodge
-   Find Bigfoot
-   Personal website
-   Platformer
-   Wikibot

closes #1263 
also resolves #1702 