### PR TITLE
Update author on Muse workshop

### DIFF
--- a/workshops/muse/README.md
+++ b/workshops/muse/README.md
@@ -1,7 +1,7 @@
 ---
 name: 'Muse: A Language for Jamming'
 description: 'compose music with code'
-author: 'Leo McElroy'
+author: '@leomcelroy'
 ---
 
 # Muse


### PR DESCRIPTION
Right now, because the author on the Muse workshop is "Leo McElroy", it looks weird on the website:

<img width="682" alt="Screen Shot 2021-10-30 at 2 05 54 PM" src="https://user-images.githubusercontent.com/14811170/139553338-582584c3-050e-4c13-819b-1d3f77583543.png">

This PR updates the author to Leo's GitHub username so that it can display his GitHub username and look better on the website.