### PR TITLE
Fixed undefined variable in incorrect password check

### DIFF
--- a/workshops/python_password_generator/README.md
+++ b/workshops/python_password_generator/README.md
@@ -194,7 +194,7 @@ Now we will check whether or not the password the user initially inputted is the
 Under the `print()` statement, still in the for loop, add:
 
 ```py
-if(hash_data == line):
+if(pwd == line):
   print(FColor.GREEN + "Correct Password")
 else:
   print(FColor.RED + f'Incorrect Password')


### PR DESCRIPTION
Replaced 'hash_data', an undefined variable, with 'pwd'.

Tested to work properly.