### PR TITLE
remove dead easter egg from rust text game workshop

### DIFF
--- a/workshops/rust_text_game/README.md
+++ b/workshops/rust_text_game/README.md
@@ -420,5 +420,3 @@ You can also check out [this remix](https://repl.it/@cfanoulis/stickerquest-para
 - [The Rust Programming Language - an in-depth guide to Rust. This workshop has been inspired by Chapter 2 of the book](https://doc.rust-lang.org/book)
 - [Rust By Example - For those that prefer code examples rather than pages of documentation](https://doc.rust-lang.org/stable/rust-by-example/)
 - [Rust's learning resources page - including guides to advanced courses on other topics](https://www.rust-lang.org/learn)
-
-You may also be interested in listening to [Charalampos's mixtape](https://hackropolis.club/mixtape). Shameless plug, I know.

--- a/workshops/rust_text_game/pt-br.md
+++ b/workshops/rust_text_game/pt-br.md
@@ -417,6 +417,4 @@ Você também pode conferir [este remix](https://repl.it/@hcbjcentro/StickerQues
 - [Rust By Example - Para aqueles que preferem exemplos de código em vez de páginas de documentação](https://doc.rust-lang.org/stable/rust-by-example/)
 - [Rust's learning resources page - incluindo guias para cursos avançados sobre outros tópicos](https://www.rust-lang.org/learn)
 
-Você também pode estar interessado em ouvir [a mixtape do Charalampos](https://hackropolis.club/mixtape). Propaganda sem vergonha, eu sei.
-
 Agora que você terminou de construir este maravilhoso projeto, compartilhe sua bela criação com outras pessoas! Lembre-se, é só mandar a URL do seu projeto!


### PR DESCRIPTION
With [Hackropolis' sunset](https://hackropolis.club) long behind us, I forgot I included an easter egg that depended on the old website. This PR clears the workshop files from the dead link