### PR TITLE
Fix feature_extractor workshop for latest ml5.js

### DIFF
--- a/workshops/feature_extractor/README.md
+++ b/workshops/feature_extractor/README.md
@@ -203,7 +203,7 @@ function gotResults(err, result) {
   if (err) {
     console.log(err)
   }
-  select('body').style('background', result)
+  select('body').style('background', result[0].label) // set background to most likely color
   classify()
 }
 ```


### PR DESCRIPTION
The result variable doesn't return the string label of the prediction anymore; it returns an array of the prediction labels and their likelihoods. This fixes the workshop so it works with that change.