### PR TITLE
Fix console link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here on GitHub, there are many ways to contribute:
 
 - [Draw a 🦕 dino](https://hack.af/draw-dino) & submit a PR to [`hackclub/dinosaurs`](https://github.com/hackclub/dinosaurs).
 
-- Create a game in [🍃 Sprig](https://sprig.hackclub.com) (we'll ship you a [console](https://github.com/hackclub/sprig-hardware)!).
+- Create a game in [🍃 Sprig](https://sprig.hackclub.com) (we'll ship you a [console](https://github.com/hackclub/sprig/tree/main/hardware)!).
 
 - Multilingual? Help us [translate our site](https://github.com/hackclub/global/issues/15)!
 


### PR DESCRIPTION
the sprig console link was previously pointed to an deprecated repository. I've edited the link to point to the new URL, https://github.com/hackclub/sprig/tree/main/hardware as linked in the original repo
fixes #1863 