### PR TITLE
Change some repl.it links to GitHub links

### DIFF
--- a/workshops/kuizzy/README.md
+++ b/workshops/kuizzy/README.md
@@ -11,7 +11,7 @@ Love [Kahoot](https://kahoot.com/)? I do! Today we're making a Kahoot clone—Ku
 - [Socket.io](https://socket.io/), a [WebSocket protocol](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) library which lets our webpage maintain a persistent connection with the server, 
 - and [Node.js](https://nodejs.org/).
 
-Here's the [final code](https://repl.it/@KhushrajRathod/Kuizzy#app.js) and [live demo](https://kuizzy.khushrajrathod.com).
+Here's the [final code](https://github.com/khrj/hackclub-workshops/blob/main/showcase/Kuizzy/app.js) and [live demo](https://kuizzy.khushrajrathod.com).
 
 If you get stuck anywhere in this workshop, I'm @KhushrajRathod -- feel free to ping me.
 
@@ -50,7 +50,7 @@ Follow these steps:
 ## Part 2: The Starter Code
 
 We'll be focusing on JavaScript for this workshop, so I've already done the HTML and CSS for you.
-To get started, go to this [Starter Code](https://repl.it/@KhushrajRathod/Kuizzy-starter) and fork it
+To get started, go to this [Starter Code](https://github.com/khrj/hackclub-workshops/tree/main/showcase/Kuizzy-starter) and fork it
 
 If you take a look at the starter code, you'll see the following:
 
@@ -647,9 +647,9 @@ You should have a fully functional Kahoot clone, Kuizzy, ready!
 
 Now that you've managed to build a simple Kahoot clone, add some more functionality to make it EXTREMELY USEFUL. This is for you to hack on, but here are ideas (ascending difficulty -- I've done 3 for you to be used as reference).
 
-01. [Add custom waiting messages ("Were you tooooooo fast?")](https://repl.it/@KhushrajRathod/Kuizzy-custom-messages)
-02. [Give points based on time](https://repl.it/@KhushrajRathod/Kuizzy-time-points)
-03. [Add an option to skip questions](https://repl.it/@KhushrajRathod/Kuizzy-skippable-questions)
+01. [Add custom waiting messages ("Were you tooooooo fast?")](https://github.com/khrj/hackclub-workshops/tree/main/showcase/Kuizzy-custom-messages)
+02. [Give points based on time](https://github.com/khrj/hackclub-workshops/tree/main/showcase/Kuizzy-time-points)
+03. [Add an option to skip questions](https://github.com/khrj/hackclub-workshops/tree/main/showcase/Kuizzy-skippable-questions)
 04. Add a way for the host to see the number of answers while the question is in progress
 05. Add music with the HTML5 AudioElement
 06. Add options for True/false questions

--- a/workshops/slack_todo_list/README.md
+++ b/workshops/slack_todo_list/README.md
@@ -9,7 +9,7 @@ Ever wanted a todo list that's simple, easy, and integrated into your favorite m
 
 Today, we'll be creating a Slack bot that maintains a todo list using [Bolt.js](https://slack.dev/bolt-js/) and [Node.js](https://nodejs.org/)
 
-Here's the [final code](https://repl.it/@KhushrajRathod/TodoSlackApp). A live demo is available as "@Todo Bot" on the [Hack Club Slack](https://hackclub.com/slack/).
+Here's the [final code](https://github.com/khrj/hackclub-workshops/tree/main/showcase/TodoSlackApp). A live demo is available as "@Todo Bot" on the [Hack Club Slack](https://hackclub.com/slack/).
 
 If you get stuck anywhere in this workshop, feel free to ask me questions! I'm @KhushrajRathod.
 
@@ -288,10 +288,10 @@ At the moment, your bot will go offline after an hour due to your repl going to 
 
 Now that you've managed to build a simple Todo list bot, build upon it and MAKE IT EXTREMELY USEFUL! This is for you to hack on, but here's some inspiration:
 
-| Repl.it code  | Live Demo on the Hack Club Slack | Description |
+| Code  | Live Demo on the Hack Club Slack | Description |
 | ------------- | -------------------------------- | ----------- |
-| [Here](https://repl.it/@KhushrajRathod/TodoSlackApp-Markable) | "@Todo List Plus" | This todo list bot let's you mark items as done (and un-mark them) without removing them from the todo list by striking through them. |
-| [Here](https://repl.it/@KhushrajRathod/TodoSlackApp-Random) | "@Todo List Random" | This todo list bot simply doesn't like listening to it's users and keeps replying with random messages. |
-| [Here](https://TodoSlackApp-Community.khushrajrathod.repl.co) | "@Todo List Community" | This todo list bot maintains a generic todo list that everyone can add to and remove from |
+| [Here](https://github.com/khrj/hackclub-workshops/tree/main/showcase/TodoSlackApp-Markable) | "@Todo List Plus" | This todo list bot let's you mark items as done (and un-mark them) without removing them from the todo list by striking through them. |
+| [Here](https://github.com/khrj/hackclub-workshops/tree/main/showcase/TodoSlackApp-Random) | "@Todo List Random" | This todo list bot simply doesn't like listening to it's users and keeps replying with random messages. |
+| [Here](https://github.com/khrj/hackclub-workshops/tree/main/showcase/TodoSlackApp-Community) | "@Todo List Community" | This todo list bot maintains a generic todo list that everyone can add to and remove from |
 
 Did you make something awesome? Share it on [#ship](https://hackclub.slack.com/archives/C0M8PUPU6) in the Hack Club Slack and tag me with [@KhushrajRathod](https://hackclub.slack.com/team/U01C21G88QM)!

--- a/workshops/web_chat/README.md
+++ b/workshops/web_chat/README.md
@@ -12,7 +12,7 @@ Today, most of us use tons of messaging apps. Whether it's Slack, Whatsapp, Tele
 What if we create our *own chat*?!  
 Today, we'll be creating a web chat using [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) and [Deno](https://deno.land/) (If you've previously used Node.js, check out [this talk](https://www.youtube.com/watch?v=M3BM9TB-8yA) on Deno)
 
-Here's the [final code](https://repl.it/@KhushrajRathod/DenoWebsocketChat) and [live demo](https://DenoWebsocketChat.khushrajrathod.repl.co).
+Here's the [final code](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat).
 
 If you get stuck anywhere in this workshop, feel free to ask me questions! I'm @KhushrajRathod on the [Hack Club Slack](https://hackclub.com/slack/).
 
@@ -685,15 +685,15 @@ Except... Let's actually test the application. Send the URL from above to some f
 
 We've managed to build a basic web chat, now let's build upon it and MAKE IT EXTREMELY USEFUL! This is for you to hack on, but here's some inspiration:
 
-- [Web chat with server response automation](https://repl.it/@KhushrajRathod/DenoWebsocketChat-AutomatedResponses) In this web chat, entering some messages will trigger responses from the server - Try "Hello", "Hi", "Bye", or "Creeper"
+- [Web chat with server response automation](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat-AutomatedResponses) In this web chat, entering some messages will trigger responses from the server - Try "Hello", "Hi", "Bye", or "Creeper"
 
-- [Web chat but clients spam randomly](https://repl.it/@KhushrajRathod/DenoWebsocketChat-Spam) In this web chat...There's spam. Once you join, you automatically start spamming and have no control!
+- [Web chat but clients spam randomly](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat-Spam) In this web chat...There's spam. Once you join, you automatically start spamming and have no control!
 
-- [Web chat with authentication](https://repl.it/@KhushrajRathod/DenoWebsocketChat-Auth) People using others' names to send messages? This web chat implements cookie-based authentication and allows you to use only your ID to sign in
+- [Web chat with authentication](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat-Auth) People using others' names to send messages? This web chat implements cookie-based authentication and allows you to use only your ID to sign in
 
 ## Cool Web Chats made by Hack clubbers
 
-- [@faisalsayed10](https://repl.it/@KhushrajRathod/Fayd-Webchat)
-- [@aaryanporwal](https://repl.it/@KhushrajRathod/Aaryan-Webchat)
+- [@faisalsayed10](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat-Fayd-Demo)
+- [@aaryanporwal](https://github.com/khrj/hackclub-workshops/tree/main/showcase/DenoWebsocketChat-Aaryan-Demo)
 
 Did you make something awesome? Share it on [#ship](https://hackclub.slack.com/archives/C0M8PUPU6) in the Hack Club Slack and tag me with [@KhushrajRathod](https://hackclub.slack.com/team/U01C21G88QM)!


### PR DESCRIPTION
I emptied my repl.it recently, but some of the workshops I wrote still link to demos on my profile. I've put the code for those demos on GitHub, and changed the links in the workshops