### PR TITLE
Update and fix instructions for the personal website workshop

### DIFF
--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -32,9 +32,9 @@ To get started, make a Github account (or login if you have one) at [https://git
 
 Then, go to [https://github.com/new](https://github.com/new). 
 
-Enter a name, check the box that says "Add a README file", and then click "Create repository"
+Enter a name, select "MIT License" underneath "Choose a license", and then click "Create repository"
 
-![Input fields for creating a repository](https://cloud-l7uo7n5dd-hack-club-bot.vercel.app/0screenshot_2024-10-04_at_08-58-54_new_repository.png)
+![Input fields for creating a repository](https://cloud-jyzgt07rh-hack-club-bot.vercel.app/0image.png)
 
 Next, go to [https://github.com/codespaces/new](https://github.com/codespaces/new).
 

--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -155,11 +155,11 @@ Save your `index.html` and look at the Live Preview. Yay!
 
 First, find an image you would like to include in your page. You can find something on Google Images, Facebook, or Imgur. We'll need the source URL of the image, so right click and select "Copy Image Address".
 
-Images are included in HTML via the image tag, or `<img>`. The image tag has an attribute called `src`, which will hold the _source_ URL of the image you want to display. As an example, if I were to add this picture of Prophet Orpheus, I would right click it and get the source URL, which in this case is https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png, and put it in an image tag like so:
+Images are included in HTML via the image tag, or `<img>`. The image tag has an attribute called `src`, which will hold the _source_ URL of the image you want to display. As an example, if I were to add this picture of Prophet Orpheus, I would right click it and get the source URL, which in this case is https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png, and put it in an image tag like so:
 
 ```html
 <img
-  src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+  src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
 />
 ```
 
@@ -173,7 +173,7 @@ Go ahead and add this into your `index.html` now. I put my picture before my hea
   <head> </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Prophet Orpheus</h1>
     <p>Coder Dino</p>
@@ -216,7 +216,7 @@ Our HTML file now looks like so:
   </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Prophet Orpheus</h1>
     <p>Coder Dino</p>

--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -291,7 +291,7 @@ Then, click Always on the pop-up
 
 ![pop-up](https://cloud-8gllz91ga-hack-club-bot.vercel.app/0screenshot7.png)
 
-Now, we need to go to our GitHub account and click on the repo we created at the start of this workshop. Then, follow the instructions on the image:
+Now, we need to go to our GitHub account and open the repo we created at the start of this workshop. Once you have it open, follow the instructions in the below image:
 
 ![Github settings](https://cloud-mqt6brgrz-hack-club-bot.vercel.app/0screenshot_2024-04-18_at_15.55.28.png)
 
@@ -303,13 +303,13 @@ Now everything is wired up! You can publish your site now, or any time in the fu
 
 **Commit your changes**
 
-Whenever you drop a new feature or fix, you'll have some changed lines in your code.
+Whenever you add a new feature or fix, you'll have to commit the lines of code that you changed.
 
-Go to the "Git" tab, fill a "Commit message", and click "Commit"
+Go to the "Git" tab on the left of your codespace, fill out a "Commit message", and click "Commit"
 
 ![Git tab](https://cloud-a7ulcfg3e-hack-club-bot.vercel.app/0screenshot_update.png)
 
-And just like that your website is now published at the domain `USERNAME.github.io/REPONAME` on the internet for all your friends to see!
+And just like that, your new changes are now published at the URL `USERNAME.github.io/REPONAME` on the internet for all your friends to see!
 
 _Give it 2 minutes to deploy your changes the first time!_
 

--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -32,25 +32,23 @@ To get started, make a Github account (or login if you have one) at [https://git
 
 Then, go to [https://github.com/new](https://github.com/new). 
 
-Enter a name and then click "Create repository"
+Enter a name, check the box that says "Add a README file", and then click "Create repository"
 
-![Input fields for creating a repository](https://cloud-1seqqsbpy-hack-club-bot.vercel.app/2screenshot12.png)
+![Input fields for creating a repository](https://cloud-l7uo7n5dd-hack-club-bot.vercel.app/0screenshot_2024-10-04_at_08-58-54_new_repository.png)
 
-Then click "Create a codespace"
+Next, go to [https://github.com/codespaces/new](https://github.com/codespaces/new).
 
-![Repository view](https://cloud-aoyz7ok1s-hack-club-bot.vercel.app/0screenshot10.png)
+![Create codespace](https://cloud-pp1naqu1h-hack-club-bot.vercel.app/0image.png)
 
-Then click "Create new codespace"
-
-![Create codespace](https://cloud-2db6a3th5-hack-club-bot.vercel.app/0screenshot11.png)
+Select the repository that you just created, and then then click "Create codespace"
 
 Wait a bit for the codespace to load and then you should see this:
 
 ![New codespace](https://cloud-1seqqsbpy-hack-club-bot.vercel.app/1screenshot9.png)
 
-Congrats! You created a codespace
+Congrats! You created a codespace. This is where you will write the code for your website.
 
-If you are using firefox you may have to disable Enchanced Tracking Protection
+If you are using Firefox, you may have to disable Enchanced Tracking Protection.
 
 ## Part II: The HTML File
 

--- a/workshops/personal_website/README.md
+++ b/workshops/personal_website/README.md
@@ -358,6 +358,7 @@ A good way to get ideas for what to add to your website is to look at other peop
 These are some additional resources that you can use to make your site even better!
 
 - [HTML Dog](http://www.htmldog.com/guides/html/beginner/): _Very beginner focused. If you're not sure which one to choose, pick this one._
+  - If you also want to learn more about how to style your website with CSS, check out their [CSS tutorial](https://www.htmldog.com/guides/css/beginner/).
 - [Free Code Camp](http://www.freecodecamp.com/map): _Interactive and very methodical._
 - [Treehouse](https://teamtreehouse.com/library/html/introduction/): _Their videos are extremely comprehensive and thorough._
 

--- a/workshops/personal_website/es-xl.md
+++ b/workshops/personal_website/es-xl.md
@@ -114,11 +114,11 @@ Ejecuta tu `index.html` y actualiza la vista previa en vivo. ¡Yay!
 
 Primero, busca una imagen que te gustaría incluir en tu página. Puedes encontrar algo en Google Images, Facebook o Imgur. Necesitaremos la URL de origen de la imagen, así que da clic derecho y selecciona "Copiar dirección de imagen".
 
-Las imágenes se incluyen en HTML a través de la etiqueta de imagen, o `<img>`. La etiqueta de la imagen tiene un atributo llamado `src`, que contendrá la _fuente_ de la URL de la imagen que deseas mostrar. Por ejemplo, si tuviera que agregar esta imagen del Profeta Orfeo, daría clic derecho y obtendría la URL de origen, que en este caso es https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png para ponerla en una etiqueta de imagen de esta forma:
+Las imágenes se incluyen en HTML a través de la etiqueta de imagen, o `<img>`. La etiqueta de la imagen tiene un atributo llamado `src`, que contendrá la _fuente_ de la URL de la imagen que deseas mostrar. Por ejemplo, si tuviera que agregar esta imagen del Profeta Orfeo, daría clic derecho y obtendría la URL de origen, que en este caso es https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png para ponerla en una etiqueta de imagen de esta forma:
 
 ```html
 <img
-  src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+  src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
 />
 ```
 
@@ -132,7 +132,7 @@ Continúa y agrega esto en tu `index.html` . Yo puse mi imagen antes de mi encab
   <head> </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Prophet Orpheus</h1>
     <p>Coder Dino</p>
@@ -178,7 +178,7 @@ Nuestro archivo HTML ahora se ve así:
   </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Prophet Orpheus</h1>
     <p>Coder Dino</p>

--- a/workshops/personal_website/pt-br.md
+++ b/workshops/personal_website/pt-br.md
@@ -119,11 +119,11 @@ Execute seu `index.html` e veja a visualização ao vivo. Uhuul!
 
 Primeiro, encontre uma imagem que você gostaria de incluir em sua página. Você pode encontrar algo no Google Imagens, Facebook, ou Imgur. Vamos precisar da URL de origem da imagem, então clique com o botão direito do mouse e selecione "Copiar endereço da imagem".
 
-As imagens são incluídas no HTML por meio da tag de imagem ou `<img>`. A tag de imagem possui um atributo chamado `src`, que conterá a URL _source_ da imagem que você deseja exibir. Por exemplo, se eu adicionasse esta foto do Profeta Orfeu, clicaria com o botão direito e obteria o URL de origem, que neste caso é https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png , e coloque-o em uma tag de imagem desse jeito:
+As imagens são incluídas no HTML por meio da tag de imagem ou `<img>`. A tag de imagem possui um atributo chamado `src`, que conterá a URL _source_ da imagem que você deseja exibir. Por exemplo, se eu adicionasse esta foto do Profeta Orfeu, clicaria com o botão direito e obteria o URL de origem, que neste caso é https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png , e coloque-o em uma tag de imagem desse jeito:
 
 ```html
 <img
-  src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+  src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
 />
 ```
 
@@ -137,7 +137,7 @@ Vá em frente e adicione isso ao seu `index.html` agora. Coloquei minha foto ant
   <head> </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Profeta Orfeu</h1>
     <p>Dino programadora</p>
@@ -181,7 +181,7 @@ Nosso arquivo HTML agora parecerá com isso:
   </head>
   <body>
     <img
-      src="https://github.com/hackclub/dinosaurs/raw/master/smart_dinosaur_docs.png"
+      src="https://github.com/hackclub/dinosaurs/raw/main/smart_dinosaur_docs.png"
     />
     <h1>Profeta Orfeu</h1>
     <p>Dino programadora</p>


### PR DESCRIPTION
Some of the instructions in the [personal website](https://workshops.hackclub.com/personal_website/) workshop, specifically for setting up Codespaces, are no longer accurate, and other sections are a bit unclear. This PR fixes those issues, and extends the "Additional Resources" section with a CSS tutorial as well.