### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -26,7 +26,7 @@ If you join in or contribute to the Hack Club ecosystem in any way, you are enco
 Explicit enforcement of the Code of Conduct applies to all official online Hack Club groups, in-person meetings, and events including:
 
 - The [Slack](https://hackclub.com/slack/)
-- The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), [Hack Night](https://hackclub.com/night/), & Zoom calls on Slack
+- The [Events](https://events.hackclub.com/), including but not limited to [AMAs](https://hackclub.com/amas/), [Hack Night](https://hackclub.com/night/), & Zoom calls on Slack
 - The [GitHub projects](https://github.com/hackclub)
 - Club Meetings
 


### PR DESCRIPTION
Patched a legal loophole in the Code of Conduct that made any event not directly listed on line 29 not included under the terms by adding "but not limited to". For example, the High Seas event is not under the current Code of Conduct.