### PR TITLE
Change project setup link to Hack Club Spaces

### DIFF
--- a/workshops/find_bigfoot/README.md
+++ b/workshops/find_bigfoot/README.md
@@ -28,7 +28,7 @@ Links to a live demo and the final code below. This workshop should take around 
 
 ## Set Up the Project
 
-Open a new HTML project on [**repl.it**/languages/html](https://repl.it/languages/html)
+Open a new Space on [spaces.hackclub.com](https://spaces.hackclub.com) and open an HTML file (name it index.html)!
 
 ### Get Images for the Game
 


### PR DESCRIPTION
This pr changes the workshop’s suggestion of using Replit (which is now a viebcoding tool) to using Hack Club’s [Spaces](https://spaces.hackclub.com).