### PR TITLE
Change Hackclub Poster Creator to Hack Club Poster Creator to follow the Hack Club branding

### DIFF
--- a/clubs/posters/simple_red_poster_source/index.html
+++ b/clubs/posters/simple_red_poster_source/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Hackclub Poster Creator</title>
+    <title>Hack Club Poster Creator</title>
     <link
       href="https://fonts.googleapis.com/css?family=Amaranth"
       rel="stylesheet"


### PR DESCRIPTION
https://hackclub.enterprise.slack.com/archives/C07MUPSKYUS/p1759977663690819
[This fix was made with the use of automated tools]