### PR TITLE
Change hackclub to Hack Club to follow the Hack Club branding

### DIFF
--- a/workshops/feature_extractor/README.md
+++ b/workshops/feature_extractor/README.md
@@ -239,6 +239,6 @@ ml5.js can do crazy things! You can integrate image classification into your own
 
 You should take a look at the many [examples on the ml5.js website](https://ml5js.org/docs/quick-start) - or take a look at [Dan Shiffman's videos on ml5.js](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6YPSwT06y_AEYTqIwbeam3y), he covers loads of things you can do with it - and explains everything with a ton of energy. I highly recommend watching his videos on the [Coding Train](https://www.youtube.com/user/shiffman) YouTube!
 
-If you have any questions or need any help with a project you're building, feel free to ping @jajoosam on the hackclub slack :)
+If you have any questions or need any help with a project you're building, feel free to ping @jajoosam on the Hack Club Slack :)
 
 > _A big thank you to repl.it for allowing us to republish this workshop!_

--- a/workshops/slack_todo_list/README.md
+++ b/workshops/slack_todo_list/README.md
@@ -69,7 +69,7 @@ Follow these steps:
 ![Arrows pointing to various places: 1. "Basic Information" on left sidebar, 2. "Add features and functionality" and 3. "Slash commands" in the dropdown](https://cdn.hackclub.com/rescue?url=https://cloud-ccj49d17x.vercel.app/2basicinfo-features-slashcommands.png)
 
 - Click "Create new command" and fill in the details for your command:
-    - Command: /todolist (Note: If you're using the hackclub workspace, you'll need to use a different name for your command, such as /yournametodolist)
+    - Command: /todolist (Note: If you're using the Hack Club workspace, you'll need to use a different name for your command, such as /yournametodolist)
     - Request URL: https://yourappname.yourusername.repl.co/slack/events where `yourappname` is your repl's name and `yourusername` is your repl.it username. For e.x., my repl's name is TodoSlackApp and my repl.it username is KhushrajRathod, so my request URL is https://TodoSlackApp.KhushrajRathod.repl.co/slack/events
     - Short Description: Show your todo list
 


### PR DESCRIPTION
https://github.com/hackclub/hackclub/blob/main/workshops/feature_extractor/README.md#L242
https://github.com/hackclub/hackclub/blob/main/workshops/slack_todo_list/README.md#L72

[This fix was made with the use of automated tools]